### PR TITLE
add lib path option to cli and properly handle paths (cross-os)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, Write};
+use std::path::PathBuf;
 use std::time::Instant;
 
 use clap::{App, Arg};
@@ -97,6 +98,14 @@ fn main() {
                 .long("verbose")
                 .short("v"),
         )
+        .arg(
+            Arg::with_name("lib")
+                .help("Path to `node_modules`.")
+                .long("lib")
+                .short("l")
+                .takes_value(true)
+                .default_value("./node_modules/"),
+        )
         .get_matches();
 
     println!(
@@ -170,11 +179,15 @@ ___  ___      _       _         _   _      _
     };
 
     println!("{}", ("Compiling...\n").to_string().bright_green());
-    let compiler = Compiler::default()
-        .export_table()
-        .runtime("stub")
-        .optimize()
-        .debug();
+    let compiler = Compiler::new(PathBuf::from(
+        matches
+            .value_of("lib")
+            .expect("unexpected: lib should always have a value"),
+    ))
+    .export_table()
+    .runtime("stub")
+    .optimize()
+    .debug();
 
     let outputs: HashMap<String, CompileOutput> = test_sources
         .into_iter()


### PR DESCRIPTION
Addresses #199 
Should also fix Windows/WSL AssemblyScript Compiler errors encountered by some discord members.

### Notes
- I actually don't think that supporting custom `exec` and `global` options is necessary/a good idea.
They are too specific and they should always be under `node_modules` (a.k.a. `lib`) since they are Node.js dependencies.
- Doesn't the addition of a `lib` option kind of fix #218 ?