### PR TITLE
Skip compile for unchanged suites

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -78,7 +78,7 @@ impl Compiler {
         self
     }
 
-    pub fn get_paths_for(name: String, entry: fs::DirEntry) -> (Vec<String>, String) {
+    fn get_paths_for(name: String, entry: fs::DirEntry) -> (Vec<String>, String) {
         let in_files = if entry
             .file_type()
             .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
@@ -116,8 +116,15 @@ impl Compiler {
 
     pub fn execute(&self, name: String, entry: fs::DirEntry) -> CompileOutput {
         let (in_files, out_file) = Compiler::get_paths_for(name.clone(), entry);
+        let mut suite_folder = String::new();
 
-        if !Path::new(&out_file).exists() || is_source_modified(&in_files, &out_file) {
+        crate::TESTS_LOCATION.with(|path| {
+            suite_folder = format!("{}/{}", &*path.borrow(), name);
+        });
+
+        if !Path::new(&out_file).exists()
+            || self.is_source_modified(&suite_folder, &in_files, &out_file)
+        {
             Log::Info(format!("Compiling {}...", name.bright_blue())).println();
 
             self.compile(in_files, out_file)
@@ -161,27 +168,36 @@ impl Compiler {
             file: out_file,
         }
     }
-}
 
-fn is_source_modified(in_files: &[String], out_file: &str) -> bool {
-    let mut is_modified = false;
+    fn is_source_modified(&self, test_folder: &str, in_files: &[String], out_file: &str) -> bool {
+        let mut is_modified = false;
 
-    let wasm_modified = fs::metadata(out_file)
-        .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
-        .modified()
-        .unwrap();
-
-    for file in in_files {
-        let in_file_modified = fs::metadata(file)
+        let wasm_modified = fs::metadata(out_file)
             .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
             .modified()
             .unwrap();
 
-        if in_file_modified > wasm_modified {
-            is_modified = true;
-            break;
-        }
-    }
+        let suite_folder_modified = fs::metadata(test_folder)
+            .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
+            .modified()
+            .unwrap();
 
-    is_modified
+        if suite_folder_modified > wasm_modified {
+            is_modified = true
+        } else {
+            for file in in_files {
+                let in_file_modified = fs::metadata(file)
+                    .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
+                    .modified()
+                    .unwrap();
+
+                if in_file_modified > wasm_modified {
+                    is_modified = true;
+                    break;
+                }
+            }
+        }
+
+        is_modified
+    }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -123,7 +123,7 @@ impl Compiler {
         });
 
         if !Path::new(&out_file).exists()
-            || self.is_source_modified(&suite_folder, &in_files, &out_file)
+            || Compiler::is_source_modified(&suite_folder, &in_files, &out_file)
         {
             Log::Info(format!("Compiling {}...", name.bright_blue())).println();
 
@@ -169,7 +169,7 @@ impl Compiler {
         }
     }
 
-    fn is_source_modified(&self, test_folder: &str, in_files: &[String], out_file: &str) -> bool {
+    fn is_source_modified(test_folder: &str, in_files: &[String], out_file: &str) -> bool {
         let mut is_modified = false;
 
         let wasm_modified = fs::metadata(out_file)

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -148,7 +148,7 @@ impl Compiler {
     }
 }
 
-pub fn should_compile(in_files: &[String], out_file: &str) -> bool {
+pub fn is_source_modified(in_files: &[String], out_file: &str) -> bool {
     let mut is_modified = false;
 
     let wasm_modified = fs::metadata(out_file)

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,8 +1,6 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
-
-use colored::Colorize;
 
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
@@ -24,29 +22,6 @@ pub struct CompileOutput {
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
     pub file: String,
-}
-
-fn is_modified(in_files: &[String], out_file: &str) -> bool {
-    let mut is_modified = false;
-
-    let wasm_modified = fs::metadata(out_file)
-        .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
-        .modified()
-        .unwrap();
-
-    for file in in_files {
-        let in_file_modified = fs::metadata(file)
-            .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
-            .modified()
-            .unwrap();
-
-        if in_file_modified > wasm_modified {
-            is_modified = true;
-            break;
-        }
-    }
-
-    is_modified
 }
 
 #[allow(dead_code)]
@@ -102,7 +77,7 @@ impl Compiler {
         self
     }
 
-    fn get_paths_for(name: String, entry: fs::DirEntry) -> (Vec<String>, String) {
+    pub fn get_paths_for(name: String, entry: fs::DirEntry) -> (Vec<String>, String) {
         let in_files = if entry
             .file_type()
             .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
@@ -138,43 +113,60 @@ impl Compiler {
         return (in_files, format!("./tests/.bin/{}.wasm", name));
     }
 
-    pub fn compile(&self, name: String, entry: fs::DirEntry) -> CompileOutput {
-        let (in_files, out_file) = Compiler::get_paths_for(name.clone(), entry);
+    pub fn compile(&self, in_files: Vec<String>, out_file: String) -> CompileOutput {
+        let output = Command::new(&self.exec)
+            .args(in_files)
+            .arg(&self.global)
+            .arg("--lib")
+            .arg(&self.lib)
+            .args(&self.options)
+            .arg("--outFile")
+            .arg(out_file.clone())
+            .output()
+            .unwrap_or_else(|err| {
+                panic!(
+                    "{}",
+                    Log::Critical(format!("Internal error during compilation: {}", err)),
+                );
+            });
 
-        if !Path::new(&out_file).exists() || is_modified(&in_files, &out_file) {
-            Log::Info(format!("Compiling {}...", &name.bright_blue())).println();
-
-            let output = Command::new(&self.exec)
-                .args(in_files)
-                .arg(&self.global)
-                .arg("--lib")
-                .arg(&self.lib)
-                .args(&self.options)
-                .arg("--outFile")
-                .arg(out_file.clone())
-                .output()
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "{}",
-                        Log::Critical(format!("Internal error during compilation: {}", err)),
-                    );
-                });
-
-            CompileOutput {
-                status: output.status,
-                stdout: output.stdout,
-                stderr: output.stderr,
-                file: out_file,
-            }
-        } else {
-            Log::Info(format!("{} skipped!", &name.bright_blue())).println();
-
-            CompileOutput {
-                status: ExitStatusExt::from_raw(0),
-                stdout: vec![],
-                stderr: vec![],
-                file: out_file,
-            }
+        CompileOutput {
+            status: output.status,
+            stdout: output.stdout,
+            stderr: output.stderr,
+            file: out_file,
         }
     }
+
+    pub fn skip_compile(&self, out_file: String) -> CompileOutput {
+        CompileOutput {
+            status: ExitStatusExt::from_raw(0),
+            stdout: vec![],
+            stderr: vec![],
+            file: out_file,
+        }
+    }
+}
+
+pub fn should_compile(in_files: &[String], out_file: &str) -> bool {
+    let mut is_modified = false;
+
+    let wasm_modified = fs::metadata(out_file)
+        .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
+        .modified()
+        .unwrap();
+
+    for file in in_files {
+        let in_file_modified = fs::metadata(file)
+            .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
+            .modified()
+            .unwrap();
+
+        if in_file_modified > wasm_modified {
+            is_modified = true;
+            break;
+        }
+    }
+
+    is_modified
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
 
 use clap::{App, Arg};
@@ -197,23 +197,7 @@ ___  ___      _       _         _   _      _
 
     let outputs: HashMap<String, CompileOutput> = test_sources
         .into_iter()
-        .map(|(name, entry)| {
-            let (in_files, out_file) = Compiler::get_paths_for(name.clone(), entry);
-
-            let output = if !Path::new(&out_file).exists()
-                || compiler::is_source_modified(&in_files, &out_file)
-            {
-                Log::Info(format!("Compiling {}...", name.bright_blue())).println();
-
-                compiler.compile(in_files, out_file)
-            } else {
-                Log::Info(format!("{} skipped!", name.bright_blue())).println();
-
-                compiler.skip_compile(out_file)
-            };
-
-            (name, output)
-        })
+        .map(|(name, entry)| (name.clone(), compiler.execute(name, entry)))
         .collect();
 
     if outputs.values().any(|output| !output.status.success()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use clap::{App, Arg};
@@ -197,7 +197,23 @@ ___  ___      _       _         _   _      _
 
     let outputs: HashMap<String, CompileOutput> = test_sources
         .into_iter()
-        .map(|(name, entry)| (name.clone(), compiler.compile(name, entry)))
+        .map(|(name, entry)| {
+            let (in_files, out_file) = Compiler::get_paths_for(name.clone(), entry);
+
+            let output = if !Path::new(&out_file).exists()
+                || compiler::should_compile(&in_files, &out_file)
+            {
+                Log::Info(format!("Compiling {}...", name.bright_blue())).println();
+
+                compiler.compile(in_files, out_file)
+            } else {
+                Log::Info(format!("{} skipped!", name.bright_blue())).println();
+
+                compiler.skip_compile(out_file)
+            };
+
+            (name, output)
+        })
         .collect();
 
     if outputs.values().any(|output| !output.status.success()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,7 @@ ___  ___      _       _         _   _      _
             let (in_files, out_file) = Compiler::get_paths_for(name.clone(), entry);
 
             let output = if !Path::new(&out_file).exists()
-                || compiler::should_compile(&in_files, &out_file)
+                || compiler::is_source_modified(&in_files, &out_file)
             {
                 Log::Info(format!("Compiling {}...", name.bright_blue())).println();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,7 @@ ___  ___      _       _         _   _      _
         .map(|(key, val)| (key.clone(), TestSuite::from(val)))
         .collect();
 
-    println!("{}", ("Igniting tests 🔥\n").to_string().bright_red());
+    println!("{}", ("\nIgniting tests 🔥\n").to_string().bright_red());
 
     let (mut num_passed, mut num_failed) = (0, 0);
     let failed_suites: HashMap<String, HashMap<String, TestResult>> = test_suites


### PR DESCRIPTION
Issues:
closes https://github.com/LimeChain/matchstick/issues/223

What it does:
1. Adds a check if a `wasm` binary already exists for each suite.
2. Adds a check (`is_source_modified` function) if any of the `.test.ts` files in each suite has been changed since the last time the `wasm` binary was compiled. The function first checks if the whole suite folder has been modified, e.g. files have been removed/added, if not - loops through each suite's files and compares `modified` time with the binary `modified` time. If any test file has been changed since the last time the suite has been compiled, the loop breaks, the function returns `true` and the suite is recompiled. - **UPDATED**
3. Adds `#skip_compile` method to `impl Compiler`, that returns a `CompileOutput` struct with a mocked `ExitStatus` using the `ExitStatusExt*` trait.
4. Extracts `let (in_files, out_file) = Compiler::get_paths_for(name.clone(), entry);` from `#compile` to `main.rs`, because `in_files` and `out_file` are used to check if any files were changed.
5. Had to change the arguments which `#compile` accepts. It is usually not a good thing and goes against the design principles, but on the other hand imo `#compile` should not be bothered with the logic if it should compile the suite or not and this logic should be outside the method.
6. Prints to the logs which test are being compiled and which have been skipped.

`* ExitStatusExt` has a `unix` and `windows` versions. I have included it like this, but I don't know if this is the correct way:
```
#[cfg(unix)]
use std::os::unix::process::ExitStatusExt;

#[cfg(windows)]
use std::os::winows::process::ExitStatusExt;
```
The alternative is using `Command::new()` with some dummy command like `echo` and using the status from the output (hacky) 

Screenshots:
<img width="701" alt="Screenshot 2021-12-06 at 14 32 47" src="https://user-images.githubusercontent.com/20456492/144847060-2469ee48-bc83-4517-bb79-0d9a286b3a44.png">
<img width="701" alt="Screenshot 2021-12-06 at 14 32 57" src="https://user-images.githubusercontent.com/20456492/144847079-463be8f5-b3e7-4bd0-b243-d5538250c473.png">