### PR TITLE
Fix missing logStore logs

### DIFF
--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -91,6 +91,9 @@ impl Test {
         }
 
         // Print the logs after the test result.
+        if passed && !logs.is_empty() {
+            println!("{}", logs);
+        }
 
         self.after();
         TestResult { passed, logs }


### PR DESCRIPTION
Issues:
closes https://github.com/LimeChain/matchstick/issues/245

**What this PR does:**
Fixes `logStore()` not displaying anything

**Notes:**

1. If the test passes, the Store log is displayed under the passing test name.
2. If the test fails, the Store log is displayed at the bottom before the backtrace.
3. If `logStore()` is invoked after an `assert()` that fails it will not log anything, because the execution will be aborted before the function invocation.

**Screenshots:**

Success:
<img width="1061" alt="Screenshot 2021-12-15 at 13 17 26" src="https://user-images.githubusercontent.com/20456492/146180472-4b7f654c-75dd-46aa-82b9-98985e789a17.png">
Fail:
<img width="1061" alt="Screenshot 2021-12-15 at 13 38 52" src="https://user-images.githubusercontent.com/20456492/146180478-e753fde2-81d9-4c1e-9340-8cfbe649cf4c.png">

