### PR TITLE
Remove hardcoded ./tests folder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run -e ARGS="gravity" -it --rm --mount type=bind,source=<absolute/path/to
 
 After that you can go straight to [the final setup step](https://github.com/LimeChain/matchstick/tree/dockerize#install-dependencies) and you'll be all set to start writing your first unit test.
 
-❗ If you have previously ran `graph test` you may encounter the following error during `docker build`: `error from sender: failed to xattr node_modules/binary-install-raw/bin/binary-<platform>: permission denied`. In this case create a file named `.dockeringore` in the root folder and add `node_modules/binary-install-raw/bin`
+❗ If you have previously ran `graph test` you may encounter the following error during `docker build`: `error from sender: failed to xattr node_modules/binary-install-raw/bin/binary-<platform>: permission denied`. In this case create a file named `.dockerignore` in the root folder and add `node_modules/binary-install-raw/bin`
 
 ❗ Although using the Docker approach is easy, we highly recommend using **Matchstick** via OS-specific binary (which is downloaded automatically when you run `graph test`). The Docker approach should only be considered if for some reason you cannot get `graph test` to work, or if you just want to quickly try something out.
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -79,6 +79,12 @@ impl Compiler {
     }
 
     fn get_paths_for(name: String, entry: fs::DirEntry) -> (Vec<String>, String) {
+        let mut bin_location = "".to_string();
+
+        crate::TESTS_LOCATION.with(|path| {
+            bin_location = format!("{}/.bin", &*path.borrow());
+        });
+
         let in_files = if entry
             .file_type()
             .unwrap_or_else(|err| panic!("{}", Log::Critical(err)))
@@ -101,17 +107,17 @@ impl Compiler {
             vec![entry.path().to_str().unwrap().to_string()]
         };
 
-        fs::create_dir_all("./tests/.bin/").unwrap_or_else(|err| {
+        fs::create_dir_all(&bin_location).unwrap_or_else(|err| {
             panic!(
                 "{}",
                 Log::Critical(format!(
-                    "Something went wrong when trying to create `./tests/.bin/`: {}",
-                    err,
+                    "Something went wrong when trying to create `{}`: {}",
+                    bin_location, err,
                 )),
             );
         });
 
-        return (in_files, format!("./tests/.bin/{}.wasm", name));
+        return (in_files, format!("{}/{}.wasm", bin_location, name));
     }
 
     pub fn execute(&self, name: String, entry: fs::DirEntry) -> CompileOutput {

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,10 +146,17 @@ ___  ___      _       _         _   _      _
     SCHEMA_LOCATION.with(|path| *path.borrow_mut() = file_location.as_str().unwrap().to_string());
     let default_tests_folder = &Value::String(String::from("./tests/"));
     let tests_folder = subgraph_yaml.get("testsFolder").unwrap_or_else(|| {
-        println!("{}", ("If you want to change the default tests folder location (./tests/) you can add 'testsFolder: ./example/path' to the outermost level of your subgraph.yaml").cyan());
+        println!("{}", ("If you want to change the default tests folder location (./tests) you can add 'testsFolder: ./example/path' to the outermost level of your subgraph.yaml").cyan());
         default_tests_folder
     });
-    TESTS_LOCATION.with(|path| *path.borrow_mut() = tests_folder.as_str().unwrap().to_string());
+    TESTS_LOCATION.with(|path| {
+        let mut tests_path = tests_folder.as_str().unwrap().to_string();
+        if tests_path.ends_with('/') {
+            tests_path.pop();
+        }
+
+        *path.borrow_mut() = tests_path;
+    });
 
     let test_sources = {
         let testable = get_testable();


### PR DESCRIPTION
Issues:
closes https://github.com/LimeChain/matchstick/issues/242

What it does:
Until now the parent folder for .bin and .tools folders was hardcoded to be `./tests`, so even if a user declares a different tests folder in the yaml file, matchstick would always create the those folders inside `./tests`.
This PR removes the hardcoded values and uses the value of TESTS_LOCATION.