### PR TITLE
Add recompile flag

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -114,10 +114,10 @@ impl Compiler {
         return (in_files, format!("./tests/.bin/{}.wasm", name));
     }
 
-    pub fn execute(&self, name: String, entry: fs::DirEntry) -> CompileOutput {
+    pub fn execute(&self, name: String, entry: fs::DirEntry, should_recompile: bool) -> CompileOutput {
         let (in_files, out_file) = Compiler::get_paths_for(name.clone(), entry);
 
-        if !Path::new(&out_file).exists() || Compiler::is_source_modified(&in_files, &out_file) {
+        if should_recompile || !Path::new(&out_file).exists() || Compiler::is_source_modified(&in_files, &out_file) {
             Log::Info(format!("Compiling {}...", name.bright_blue())).println();
 
             self.compile(in_files, out_file)

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -114,10 +114,18 @@ impl Compiler {
         return (in_files, format!("./tests/.bin/{}.wasm", name));
     }
 
-    pub fn execute(&self, name: String, entry: fs::DirEntry, should_recompile: bool) -> CompileOutput {
+    pub fn execute(
+        &self,
+        name: String,
+        entry: fs::DirEntry,
+        should_recompile: bool,
+    ) -> CompileOutput {
         let (in_files, out_file) = Compiler::get_paths_for(name.clone(), entry);
 
-        if should_recompile || !Path::new(&out_file).exists() || Compiler::is_source_modified(&in_files, &out_file) {
+        if should_recompile
+            || !Path::new(&out_file).exists()
+            || Compiler::is_source_modified(&in_files, &out_file)
+        {
             Log::Info(format!("Compiling {}...", name.bright_blue())).println();
 
             self.compile(in_files, out_file)

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
         )
         .arg(
             Arg::with_name("recompile")
-                .help("Recompiles the tests.")
+                .help("Force-recompiles the tests.")
                 .long("recompile")
                 .short("r")
                 .takes_value(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,14 @@ fn main() {
                 .required(false),
         )
         .arg(
+            Arg::with_name("recompile")
+                .help("Recompiles the tests.")
+                .long("recompile")
+                .short("r")
+                .takes_value(false)
+                .required(false),
+        )
+        .arg(
             Arg::with_name("test_suites")
                 .help("Please specify the names of the test suites you would like to run.")
                 .index(1)
@@ -197,7 +205,7 @@ ___  ___      _       _         _   _      _
 
     let outputs: HashMap<String, CompileOutput> = test_sources
         .into_iter()
-        .map(|(name, entry)| (name.clone(), compiler.execute(name, entry)))
+        .map(|(name, entry)| (name.clone(), compiler.execute(name, entry, matches.is_present("recompile"))))
         .collect();
 
     if outputs.values().any(|output| !output.status.success()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,12 @@ ___  ___      _       _         _   _      _
 
     let outputs: HashMap<String, CompileOutput> = test_sources
         .into_iter()
-        .map(|(name, entry)| (name.clone(), compiler.execute(name, entry, matches.is_present("recompile"))))
+        .map(|(name, entry)| {
+            (
+                name.clone(),
+                compiler.execute(name, entry, matches.is_present("recompile")),
+            )
+        })
         .collect();
 
     if outputs.values().any(|output| !output.status.success()) {


### PR DESCRIPTION
Issues:
closes https://github.com/LimeChain/matchstick/issues/261

What it does:
Adds a -r/--recompile flag that force-recompiles all tests