### PR TITLE
Remove cmake build from coverage

### DIFF
--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -184,7 +184,7 @@ pub fn generate_coverage_report() {
             convert_command = format!(
                 "{}{} {} {} {}",
                 &*path.borrow(),
-                "matchstick-as/node_modules/.bin/wasm2wat",
+                "wabt/bin/wasm2wat",
                 file,
                 "-o",
                 destination

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -182,9 +182,9 @@ pub fn generate_coverage_report() {
         let mut convert_command = "".to_string();
         crate::LIBS_LOCATION.with(|path| {
             convert_command = format!(
-                "{}/{} {} {} {}",
+                "{}{} {} {} {}",
                 &*path.borrow(),
-                "matchstick-as/node_modules/wabt/bin/wasm2wat",
+                "matchstick-as/node_modules/.bin/wasm2wat",
                 file,
                 "-o",
                 destination


### PR DESCRIPTION
**Issues:**
closes https://github.com/LimeChain/matchstick/issues/259

**What it does:**
Using cmake to build the wabt module every time matchstick is run in coverage mode is pretty slow.
Also it requires cmake to be installed in the docker container which also increases the build time and the image size.
We found that the [wabt](https://www.npmjs.com/package/wabt) node package runs without issues and helps fix the issues above.

**Depends on:**
matchstick-as https://github.com/LimeChain/matchstick-as/pull/40
