### PR TITLE
Display the full path  + line for each failed test

### DIFF
--- a/mocks/as/mock-includes.test.ts
+++ b/mocks/as/mock-includes.test.ts
@@ -2,3 +2,17 @@ import { handleNewGravatars, createNewGravatarEvent, trySaveGravatarFromContract
 import { test, log } from 'matchstick-as/assembly/index'
 import { Gravatar } from "../generated/schema"
 import { handleCreateGravatar, handleNewGravatar } from "../../src/gravity"
+
+test("0", () => {})
+
+test("1", () => {})
+
+test("2", () => {})
+
+test("3", () => {})
+
+test("4", () => {})
+
+test("5", () => {})
+
+test("6", () => {})

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,0 +1,63 @@
+use regex::Regex;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+pub fn parse_backtrace(logs: &str) -> (String, i32) {
+    let regex = Regex::new(r#"<unknown>!start:(.*)~anonymous\|(\d)"#).unwrap();
+    let matches = regex.captures(logs).unwrap();
+    let test_id = matches[2].parse::<i32>().unwrap();
+    let path = format!("{}.ts", &matches[1]);
+
+    (path, test_id)
+}
+
+pub fn get_test_line(file_path: &str, test_id: i32) -> i32 {
+    let mut line_number = 1;
+    let mut id = 0;
+
+    let tests = File::open(file_path).unwrap();
+    let reader = BufReader::new(tests);
+
+    for line in reader.lines() {
+        let line_as_string = line.as_ref().unwrap();
+        if line_as_string.contains("test(") {
+            if id == test_id {
+                break;
+            }
+            id += 1;
+        }
+        line_number += 1;
+    }
+
+    line_number
+}
+
+#[cfg(test)]
+mod backtrace_tests {
+    use super::*;
+
+    #[test]
+    fn it_returns_the_path_and_function_id() {
+        let backtrace = r#"🛠 Mapping aborted at ~lib/matchstick-as/assembly/assert.ts, line 13, column 7, with message: Assertion Error
+                        wasm backtrace:
+                        0: 0x2469 - <unknown>!~lib/matchstick-as/assembly/assert/assert.fieldEquals
+                        1: 0x2806 - <unknown>!start:mocks/as/mock-includes.test~anonymous|5"#;
+
+        println!("{}", backtrace);
+
+        let (file_path, test_id) = parse_backtrace(backtrace);
+
+        assert_eq!(file_path, "mocks/as/mock-includes.test.ts");
+        assert_eq!(test_id, 5);
+    }
+
+    #[test]
+    fn it_returns_the_test_line() {
+        let file_path = "mocks/as/mock-includes.test.ts";
+        let test_id = 5;
+
+        let line_number = get_test_line(&file_path, test_id);
+
+        assert_eq!(line_number, 16);
+    }
+}

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -3,8 +3,8 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 
 pub fn parse_backtrace(logs: &str) -> (String, i32) {
-    let regex = Regex::new(r#"<unknown>!start:(.*)~anonymous\|(\d)"#).unwrap();
-    let matches = regex.captures(logs).unwrap();
+    let test_path_regex = Regex::new(r#"<unknown>!start:(.*)~anonymous\|(\d)"#).unwrap();
+    let matches = test_path_regex.captures(logs).unwrap();
     let test_id = matches[2].parse::<i32>().unwrap();
     let path = format!("{}.ts", &matches[1]);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use crate::test_suite::{TestResult, TestSuite};
 
 use crate::coverage::generate_coverage_report;
 
+mod backtrace;
 mod compiler;
 mod context;
 mod coverage;
@@ -302,11 +303,17 @@ ___  ___      _       _         _   _      _
         println!("Failed tests: \n");
         for (suite, tests) in failed_suites {
             for (name, result) in tests {
-                println!("{} {}", suite.bright_blue(), name.red(),);
+                let (file_path, test_id) = backtrace::parse_backtrace(&result.logs);
+                let line_number = backtrace::get_test_line(&file_path, test_id);
 
-                if !result.logs.is_empty() {
-                    println!("{}", result.logs);
-                }
+                println!(
+                    "{} {} {}",
+                    suite.bright_blue(),
+                    name.red(),
+                    format!("at ./{}:{}", file_path, line_number).cyan()
+                );
+
+                println!("{}", result.logs);
             }
         }
 


### PR DESCRIPTION
**Issue:**
closes https://github.com/LimeChain/matchstick/issues/237

**What this PR does:**
1. Adds backtrace module
2. Adds `parse_backtrace` function - Using regex gets the line of the backtrace which contains the path of the test file and the id of the failing test function.
3. Adds `get_test_line` function - Uses the file path and the test function id from `parse_backtrace` to read the file and find the the line on which the test function was declared. 


**Drawbacks:**
Currently it will iterate over the test file for each failing test

**Screenshots:**
<img width="877" alt="Screenshot 2022-01-04 at 16 41 52" src="https://user-images.githubusercontent.com/20456492/148076054-73e5c743-202c-4cc7-9f5a-f7c88f4d74e8.png">
