### PR TITLE
Add matchstick config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 👋 Welcome to **Matchstick** - a unit testing framework for The Graph protocol. Try out your mapping logic in a sandboxed environment and ensure your handlers run correctly when deploying your awesome subgraph!
 
 ## Quick Start 🚀
+### Configuration ⚙️
+Matchstick can be configured to use a custom tests and libs folder via `matchstick.yaml` config file:
+
+- To change the default tests location (./tests), add 'testsFolder: ./custom/path'
+
+- To change the default libs location (./node_modules), add 'libsFolder: ./custom/path'
+
 ### Docker 🐳
 The quickest way to use **Matchstick** "out of the box" is to build and run an ubuntu-based Docker container with a **Matchstick** image. Steps:
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 ### Configuration ⚙️
 Matchstick can be configured to use a custom tests and libs folder via `matchstick.yaml` config file:
 
-- To change the default tests location (./tests), add 'testsFolder: ./custom/path'
+- To change the default tests location (./tests), add `testsFolder: ./custom/path`
 
-- To change the default libs location (./node_modules), add 'libsFolder: ./custom/path'
+- To change the default libs location (./node_modules), add `libsFolder: ./custom/path`
 
 ### Docker 🐳
 The quickest way to use **Matchstick** "out of the box" is to build and run an ubuntu-based Docker container with a **Matchstick** image. Steps:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,53 @@
+use serde_yaml::Value;
+use std::path::PathBuf;
+
+pub struct MatchstickConfig {
+    pub libs_path: String,
+    pub tests_path: String,
+}
+
+impl Default for MatchstickConfig {
+    fn default() -> MatchstickConfig {
+        MatchstickConfig {
+            libs_path: "./node_modules".to_string(),
+            tests_path: "./tests".to_string(),
+        }
+    }
+}
+
+pub fn parse_matchstick_config() -> MatchstickConfig {
+    let mut config = MatchstickConfig::default();
+
+    if PathBuf::from("matchstick.yaml").exists() {
+        let matchstick_config = std::fs::read_to_string("matchstick.yaml").unwrap();
+        let matchstick_yaml: Value = serde_yaml::from_str(&matchstick_config)
+            .unwrap_or_else(|_| Value::String("".to_string()));
+
+        let mut tests_path = matchstick_yaml
+            .get("testsFolder")
+            .unwrap_or(&Value::String(config.tests_path))
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let mut libs_path = matchstick_yaml
+            .get("libsFolder")
+            .unwrap_or(&Value::String(config.libs_path))
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        if tests_path.ends_with('/') {
+            tests_path.pop();
+        }
+
+        if libs_path.ends_with('/') {
+            libs_path.pop();
+        }
+        
+        config.tests_path = tests_path;
+        config.libs_path = libs_path;
+    }
+
+    config
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 use crate::logging::Log;
 
+const CONFIG: &str = "matchstick.yaml";
+
 pub struct MatchstickConfig {
     pub libs_path: String,
     pub tests_path: String,
@@ -20,15 +22,16 @@ impl Default for MatchstickConfig {
 pub fn parse_matchstick_config() -> MatchstickConfig {
     let mut config = MatchstickConfig::default();
 
-    if PathBuf::from("matchstick.yaml").exists() {
-        let matchstick_config = std::fs::read_to_string("matchstick.yaml").unwrap();
+    if PathBuf::from(CONFIG).exists() {
+        let matchstick_config = std::fs::read_to_string(CONFIG).unwrap();
 
         // If matchstick.yaml exists but is empty from_str will panic with `EndOfStream`
         let matchstick_yaml: Value =
             serde_yaml::from_str(&matchstick_config).unwrap_or_else(|_| {
-                Log::Warning(
-                    "matchstick.yaml is empty or contains invalid values! Using default configuration.",
-                )
+                Log::Warning(format!(
+                    "{} is empty or contains invalid values! Using default configuration.",
+                    CONFIG
+                ))
                 .println();
                 Value::String("".to_string())
             });

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use serde_yaml::Value;
 use std::path::PathBuf;
 
+use crate::logging::Log;
+
 pub struct MatchstickConfig {
     pub libs_path: String,
     pub tests_path: String,
@@ -20,8 +22,16 @@ pub fn parse_matchstick_config() -> MatchstickConfig {
 
     if PathBuf::from("matchstick.yaml").exists() {
         let matchstick_config = std::fs::read_to_string("matchstick.yaml").unwrap();
-        let matchstick_yaml: Value = serde_yaml::from_str(&matchstick_config)
-            .unwrap_or_else(|_| Value::String("".to_string()));
+
+        // If matchstick.yaml exists but is empty from_str will panic with `EndOfStream`
+        let matchstick_yaml: Value =
+            serde_yaml::from_str(&matchstick_config).unwrap_or_else(|_| {
+                Log::Warning(
+                    "matchstick.yaml is empty or contains invalid values! Using default configuration.",
+                )
+                .println();
+                Value::String("".to_string())
+            });
 
         let mut tests_path = matchstick_yaml
             .get("testsFolder")

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,15 @@ pub fn parse() -> MatchstickConfig {
     let mut config = MatchstickConfig::default();
 
     if PathBuf::from(CONFIG).exists() {
-        let matchstick_config = std::fs::read_to_string(CONFIG).unwrap();
+        let matchstick_config = std::fs::read_to_string(CONFIG).unwrap_or_else(|err| {
+            panic!(
+                "{}",
+                Log::Critical(format!(
+                    "Something went wrong while trying to read `{}`: {}",
+                    CONFIG, err,
+                )),
+            )
+        });
 
         // If matchstick.yaml exists but is empty from_str will panic with `EndOfStream`
         let matchstick_yaml: Value =

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,7 @@ pub fn parse_matchstick_config() -> MatchstickConfig {
         if libs_path.ends_with('/') {
             libs_path.pop();
         }
-        
+
         config.tests_path = tests_path;
         config.libs_path = libs_path;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,9 @@ impl Default for MatchstickConfig {
     }
 }
 
-pub fn parse_matchstick_config() -> MatchstickConfig {
+/// Reads and checks if libFolder and/or testsFolder are defined.
+/// Otherwise returns the default values.
+pub fn parse() -> MatchstickConfig {
     let mut config = MatchstickConfig::default();
 
     if PathBuf::from(CONFIG).exists() {
@@ -36,6 +38,8 @@ pub fn parse_matchstick_config() -> MatchstickConfig {
                 Value::String("".to_string())
             });
 
+        // Tries to get the tests or libs folder value from the config file.
+        // If the attribute doesn't exist returns the default value.
         let mut tests_path = matchstick_yaml
             .get("testsFolder")
             .unwrap_or(&Value::String(config.tests_path))
@@ -50,6 +54,7 @@ pub fn parse_matchstick_config() -> MatchstickConfig {
             .unwrap()
             .to_string();
 
+        // For consistency checks if the paths are defined with a trailng slash and removes it
         if tests_path.ends_with('/') {
             tests_path.pop();
         }
@@ -58,6 +63,7 @@ pub fn parse_matchstick_config() -> MatchstickConfig {
             libs_path.pop();
         }
 
+        // Updates the struct attributes
         config.tests_path = tests_path;
         config.libs_path = libs_path;
     }

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -158,7 +158,7 @@ pub fn generate_coverage_report() {
 
             crate::LIBS_LOCATION.with(|path| {
                 convert_command = format!(
-                    "{}{} {} {} {:?}",
+                    "{}/{} {} {} {:?}",
                     &*path.borrow(),
                     "wabt/bin/wasm2wat",
                     file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ ___  ___      _       _         _   _      _
         .expect("Couldn't get schema file location");
     SCHEMA_LOCATION.with(|path| *path.borrow_mut() = file_location.as_str().unwrap().to_string());
 
-    let config = config::parse_matchstick_config();
+    let config = config::parse();
 
     TESTS_LOCATION.with(|path| *path.borrow_mut() = config.tests_path.clone());
     LIBS_LOCATION.with(|path| *path.borrow_mut() = config.libs_path.clone());


### PR DESCRIPTION
Issues: https://github.com/LimeChain/matchstick/issues/275

What it does:
Adds support for matchstick.yaml config, where users can declare custom `testsFolder` and `libsFolder`