### PR TITLE
Add logging macros

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -13,7 +13,7 @@ use std::os::windows::process::ExitStatusExt;
 
 mod sources;
 
-use crate::logging::{self, Log};
+use crate::logging;
 use sources::*;
 
 pub struct Compiler {
@@ -34,14 +34,7 @@ pub struct CompileOutput {
 impl Compiler {
     pub fn new(lib: PathBuf) -> Self {
         if !lib.exists() {
-            panic!(
-                "{}",
-                Log::Critical(format!(
-                    "Path to lib `{}` does not exist!",
-                    lib.to_str()
-                        .expect("unexpected: lib should always have a value"),
-                )),
-            );
+            logging::critical!("Path to lib {:?} does not exist!", lib);
         }
         Compiler {
             exec: lib.join("assemblyscript/bin/asc"),
@@ -126,12 +119,7 @@ impl Compiler {
             .arg("--outFile")
             .arg(out_file.clone())
             .output()
-            .unwrap_or_else(|err| {
-                panic!(
-                    "{}",
-                    Log::Critical(format!("Internal error during compilation: {}", err)),
-                );
-            });
+            .unwrap_or_else(|err| logging::critical!("Internal error during compilation: {}", err));
 
         CompileOutput {
             status: output.status,
@@ -157,16 +145,10 @@ fn verify_outputs(outputs: &HashMap<String, CompileOutput>) {
             io::stderr()
                 .write_all(&output.stderr)
                 .unwrap_or_else(|err| {
-                    panic!(
-                        "{}",
-                        Log::Critical(format!("Could not write to `stderr`: {}", err)),
-                    );
+                    logging::critical!("Could not write to `stderr`: {}", err);
                 });
         });
 
-        panic!(
-            "{}",
-            Log::Critical("Please attend to the compilation errors above!"),
-        );
+        logging::critical!("Please attend to the compilation errors above!");
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -13,7 +13,7 @@ use std::os::windows::process::ExitStatusExt;
 
 mod sources;
 
-use crate::logging::Log;
+use crate::logging::{self, Log};
 use sources::*;
 
 pub struct Compiler {
@@ -98,11 +98,11 @@ impl Compiler {
                     || !Path::new(&out_file).exists()
                     || is_source_modified(&in_files, &out_file)
                 {
-                    Log::Info(format!("Compiling {}...", name.bright_blue())).println();
+                    logging::info!("Compiling {}...", name.bright_blue());
 
                     self.compile(in_files, out_file)
                 } else {
-                    Log::Info(format!("{} skipped!", name.bright_blue())).println();
+                    logging::info!("{} skipped!", name.bright_blue());
 
                     self.skip_compile(out_file)
                 };

--- a/src/context.rs
+++ b/src/context.rs
@@ -137,8 +137,8 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
             0 => {
                 logging::clear_indent();
                 logging::critical!(msg)
-            },
-            _ => logging::log!(level, msg)
+            }
+            _ => logging::log!(level, msg),
         }
 
         Ok(())

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,7 +27,7 @@ use graph_runtime_wasm::{
 use lazy_static::lazy_static;
 use serde_json::to_string_pretty;
 
-use crate::logging::{self, Log};
+use crate::logging;
 use crate::SCHEMA_LOCATION;
 
 lazy_static! {
@@ -40,25 +40,19 @@ lazy_static! {
         let mut s = "".to_owned();
         SCHEMA_LOCATION.with(|path| {
             s = std::fs::read_to_string(&*path.borrow()).unwrap_or_else(|err| {
-                panic!(
-                    "{}",
-                    Log::Critical(format!(
-                        "Something went wrong when trying to read `{:?}`: {}",
-                        &*path.borrow(),
-                        err,
-                    )),
-                );
+                logging::critical!(
+                    "Something went wrong when trying to read `{:?}`: {}",
+                    &*path.borrow(),
+                    err,
+                )
             });
         });
 
         schema::parse_schema::<String>(&s).unwrap_or_else(|err| {
-            panic!(
-                "{}",
-                Log::Critical(format!(
-                    "Something went wrong when trying to parse `schema.graphql`: {}",
-                    err,
-                )),
-            );
+            logging::critical!(
+                "Something went wrong when trying to parse `schema.graphql`: {}",
+                err
+            )
         }).into_static()
     };
 }
@@ -138,12 +132,13 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         msg: AscPtr<AscString>,
     ) -> Result<(), HostExportError> {
         let msg: String = asc_get(&self.wasm_ctx, msg)?;
-        let log = Log::new(level, msg);
 
-        if let Log::Critical(_) = log {
-            panic!("{}", log);
-        } else {
-            log.println();
+        match level {
+            0 => {
+                logging::clear_indent();
+                logging::critical!(msg)
+            },
+            _ => logging::log!(level, msg)
         }
 
         Ok(())
@@ -153,7 +148,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
     pub fn log_store(&mut self, _gas: &GasCounter) -> Result<(), HostExportError> {
         logging::debug!(
             "{}",
-            to_string_pretty(&self.store).unwrap_or_else(|err| panic!("{}", Log::Critical(err))),
+            to_string_pretty(&self.store).unwrap_or_else(|err| logging::critical!(err)),
         );
         Ok(())
     }
@@ -339,10 +334,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 }
             })
             .unwrap_or_else(|| {
-                panic!(
-                    "{}",
-                    Log::Critical("Something went wrong! Could not find the entity defined in the GraphQL schema.")
-                );
+                logging::critical!("Something went wrong! Could not find the entity defined in the GraphQL schema.")
             })
             .fields
             .iter();
@@ -352,8 +344,6 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
             .filter(|&f| matches!(f.field_type, schema::Type::NonNullType(..)) && !f.is_derived());
 
         for f in required_fields {
-            // let warn = |s: String| Log::Warning(s).println();
-
             if !data.contains_key(&f.name) {
                 logging::warning!(
                     "Missing a required field '{}' for an entity of type '{}'.",
@@ -387,12 +377,9 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                     .derived
                     .get(&clean_field_type)
                     .unwrap_or_else(|| {
-                        panic!(
-                            "{}",
-                            Log::Critical(format!(
-                                "Failed to get field names vector for type {}",
-                                clean_field_type
-                            ))
+                        logging::critical!(
+                            "Failed to get field names vector for type {}",
+                            clean_field_type
                         )
                     })
                     .1
@@ -434,13 +421,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 .derived
                 .get(&entity_type)
                 .unwrap_or_else(|| {
-                    panic!(
-                        "{}",
-                        Log::Critical(format!(
-                            "Couldn't find value for key {} in derived map",
-                            entity_type
-                        ))
-                    )
+                    logging::critical!("Couldn't find value for key {} in derived map", entity_type)
                 })
                 .1
                 .clone();
@@ -450,12 +431,9 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                     let derived_field_value = data
                         .get(&linking_field.1)
                         .unwrap_or_else(|| {
-                            panic!(
-                                "{}",
-                                Log::Critical(format!(
-                                    "Couldn't find value for {} in submitted data",
-                                    linking_field.1
-                                ))
+                            logging::critical!(
+                                "Couldn't find value for {} in submitted data",
+                                linking_field.1
                             )
                         })
                         .clone();
@@ -506,25 +484,16 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                     .store
                     .get(&original_entity)
                     .unwrap_or_else(|| {
-                        panic!(
-                            "{}",
-                            Log::Critical(format!(
-                                "Couldn't find value for {} in store",
-                                original_entity
-                            ))
-                        )
+                        logging::critical!("Couldn't find value for {} in store", original_entity)
                     })
                     .clone();
                 if inner_store.contains_key(&derived_field_string_value) {
                     let mut innermost_store = inner_store
                         .get(&derived_field_string_value)
                         .unwrap_or_else(|| {
-                            panic!(
-                                "{}",
-                                Log::Critical(format!(
-                                    "Couldn't find value for {} in inner store",
-                                    derived_field_string_value
-                                ))
+                            logging::critical!(
+                                "Couldn't find value for {} in inner store",
+                                derived_field_string_value
                             )
                         })
                         .clone();
@@ -532,12 +501,9 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                         let innermost_value = innermost_store
                             .get(&linking_field.0)
                             .unwrap_or_else(|| {
-                                panic!(
-                                    "{}",
-                                    Log::Critical(format!(
-                                        "Couldn't find value for {} in innermost store",
-                                        linking_field.0
-                                    ))
+                                logging::critical!(
+                                    "Couldn't find value for {} in innermost store",
+                                    linking_field.0
                                 )
                             })
                             .clone();
@@ -604,9 +570,9 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         let fn_id = MatchstickInstanceContext::<C>::fn_id(
             &call.contract_address.to_string(),
             &call.function_name,
-            &call.function_signature.unwrap_or_else(|| {
-                panic!("{}", Log::Critical("Could not get function signature."));
-            }),
+            &call
+                .function_signature
+                .unwrap_or_else(|| logging::critical!("Could not get function signature.")),
             call.function_args,
         );
 
@@ -620,23 +586,15 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 &mut self.wasm_ctx,
                 self.fn_ret_map
                     .get(&fn_id)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "{}",
-                            Log::Critical("Could not get value from function map."),
-                        );
-                    })
+                    .unwrap_or_else(|| logging::critical!("Could not get value from function map."))
                     .as_slice(),
             )?;
 
             Ok(return_val)
         } else {
-            panic!(
-                "{}",
-                Log::Critical(format!(
-                    "Key: '{}' not found in map. Please mock the function before calling it.",
-                    &fn_id,
-                )),
+            logging::critical!(
+                "Key: '{}' not found in map. Please mock the function before calling it.",
+                &fn_id,
             );
         }
     }

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -34,7 +34,8 @@ pub fn generate_coverage_report() {
             let mut is_tested = false;
 
             for wat_file in &wat_files {
-                let wat_content = fs::read_to_string(&wat_file).expect("Couldn't read wat file.");
+                let wat_content = fs::read_to_string(&wat_file)
+                    .unwrap_or_else(|_| logging::critical!("Couldn't read wat file."));
 
                 if is_called(&wat_content, &handler) {
                     is_tested = true;
@@ -95,8 +96,8 @@ fn collect_wasm_files() -> Vec<PathBuf> {
     crate::TESTS_LOCATION.with(|path| {
         let bin_location = path.borrow().join(".bin");
 
-        let msg = format!("Couldn't find folder '{:?}.", &bin_location);
-        let entries = fs::read_dir(bin_location).expect(&msg);
+        let entries = fs::read_dir(&bin_location)
+            .unwrap_or_else(|_| logging::critical!("Couldn't find folder '{:?}.", bin_location));
 
         for entry in entries {
             let file_name = entry.unwrap().path();

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -4,25 +4,25 @@ use run_script::{run_or_exit, ScriptOptions};
 use std::fs;
 use std::path::PathBuf;
 
-use crate::logging::Log;
+use crate::logging;
 use crate::parser;
 
 pub fn generate_coverage_report() {
-    Log::Default("\nRunning in coverage report mode.\n️".to_owned().cyan()).println();
+    logging::log_with_color!(cyan, "\nRunning in coverage report mode.\n️");
 
     let source_handlers = parser::collect_handlers("subgraph.yaml");
 
-    Log::Default("Reading generated test modules... 🔎️\n".to_owned().cyan()).println();
+    logging::log_with_color!(cyan, "Reading generated test modules... 🔎️\n");
 
     let wat_files = generate_wat_files();
 
-    Log::Default("Generating coverage report 📝\n".to_owned().cyan()).println();
+    logging::log_with_color!(cyan, "Generating coverage report 📝\n");
 
     let mut global_handlers_count: i32 = 0;
     let mut global_handlers_called: i32 = 0;
 
     for (name, handlers) in source_handlers.into_iter() {
-        Log::Default(format!("Handlers for source '{}':", name)).println();
+        logging::default!("Handlers for source '{}':", name);
 
         let mut called: i32 = 0;
         let all_handlers: i32 = handlers.len().try_into().unwrap();
@@ -44,11 +44,10 @@ pub fn generate_coverage_report() {
 
             if is_tested {
                 called += 1;
-                let msg = format!("Handler '{}' is tested.", handler);
-                Log::Default(msg.green()).println();
+
+                logging::log_with_color!(green, "Handler '{}' is tested.", handler);
             } else {
-                let msg = format!("Handler '{}' is not tested.", handler);
-                Log::Default(msg.red()).println();
+                logging::log_with_color!(red, "Handler '{}' is not tested.", handler);
             }
         }
 
@@ -58,11 +57,12 @@ pub fn generate_coverage_report() {
             percentage = (called as f32 * 100.0) / all_handlers as f32;
         }
 
-        Log::Default(format!(
+        logging::default!(
             "Test coverage: {:.1}% ({}/{} handlers).\n",
-            percentage, called, all_handlers
-        ))
-        .println();
+            percentage,
+            called,
+            all_handlers
+        );
 
         global_handlers_count += all_handlers;
         global_handlers_called += called;
@@ -74,11 +74,12 @@ pub fn generate_coverage_report() {
         percentage = (global_handlers_called as f32 * 100.0) / global_handlers_count as f32;
     }
 
-    Log::Default(format!(
+    logging::default!(
         "Global test coverage: {:.1}% ({}/{} handlers).\n",
-        percentage, global_handlers_called, global_handlers_count
-    ))
-    .println();
+        percentage,
+        global_handlers_called,
+        global_handlers_count
+    );
 }
 
 fn is_called(wat_content: &str, handler: &str) -> bool {

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -8,15 +8,15 @@ use crate::logging;
 use crate::parser;
 
 pub fn generate_coverage_report() {
-    logging::log_with_color!(cyan, "\nRunning in coverage report mode.\n️");
+    logging::log_with_style!(cyan, "\nRunning in coverage report mode.\n️");
 
     let source_handlers = parser::collect_handlers("subgraph.yaml");
 
-    logging::log_with_color!(cyan, "Reading generated test modules... 🔎️\n");
+    logging::log_with_style!(cyan, "Reading generated test modules... 🔎️\n");
 
     let wat_files = generate_wat_files();
 
-    logging::log_with_color!(cyan, "Generating coverage report 📝\n");
+    logging::log_with_style!(cyan, "Generating coverage report 📝\n");
 
     let mut global_handlers_count: i32 = 0;
     let mut global_handlers_called: i32 = 0;
@@ -46,9 +46,9 @@ pub fn generate_coverage_report() {
             if is_tested {
                 called += 1;
 
-                logging::log_with_color!(green, "Handler '{}' is tested.", handler);
+                logging::log_with_style!(green, "Handler '{}' is tested.", handler);
             } else {
-                logging::log_with_color!(red, "Handler '{}' is not tested.", handler);
+                logging::log_with_style!(red, "Handler '{}' is not tested.", handler);
             }
         }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -23,7 +23,7 @@ use graph_runtime_wasm::{
 use wasmtime::Trap;
 
 use crate::subgraph_store::MockSubgraphStore;
-use crate::{context::MatchstickInstanceContext, logging::Log};
+use crate::{context::MatchstickInstanceContext, logging};
 
 /// The Matchstick Instance is simply a wrapper around WASM Instance and
 pub struct MatchstickInstance<C: Blockchain> {
@@ -37,12 +37,8 @@ pub struct MatchstickInstance<C: Blockchain> {
 impl<C: Blockchain> MatchstickInstance<C> {
     pub fn new(path_to_wasm: &str) -> MatchstickInstance<Chain> {
         let subgraph_id = "ipfsMap";
-        let deployment_id = &DeploymentHash::new(subgraph_id).unwrap_or_else(|err| {
-            panic!(
-                "{}",
-                Log::Critical(format!("Could not create deployment id: {}", err)),
-            );
-        });
+        let deployment_id = &DeploymentHash::new(subgraph_id)
+            .unwrap_or_else(|err| logging::critical!("Could not create deployment id: {}", err));
         let deployment = DeploymentLocator::new(DeploymentId::new(42), deployment_id.clone());
         let data_source = mock_data_source(path_to_wasm, Version::new(0, 0, 6));
 
@@ -69,22 +65,15 @@ impl<C: Blockchain> MatchstickInstance<C> {
         let valid_module = Arc::new(
             ValidModule::new(
                 Arc::new(std::fs::read(path_to_wasm).unwrap_or_else(|err| {
-                    panic!(
-                        "{}",
-                        Log::Critical(format!(
-                            "Something went wrong while trying to read `{}`: {}",
-                            path_to_wasm, err,
-                        )),
-                    );
+                    logging::critical!(
+                        "Something went wrong while trying to read `{}`: {}",
+                        path_to_wasm,
+                        err,
+                    )
                 }))
                 .as_ref(),
             )
-            .unwrap_or_else(|err| {
-                panic!(
-                    "{}",
-                    Log::Critical(format!("Could not create ValidModule: {}", err)),
-                );
-            }),
+            .unwrap_or_else(|err| logging::critical!("Could not create ValidModule: {}", err)),
         );
 
         MatchstickInstance::<Chain>::from_valid_module_with_ctx(
@@ -100,13 +89,10 @@ impl<C: Blockchain> MatchstickInstance<C> {
             experimental_features,
         )
         .unwrap_or_else(|err| {
-            panic!(
-                "{}",
-                Log::Critical(format!(
-                    "Could not create WasmInstance from valid module with context: {}",
-                    err,
-                )),
-            );
+            logging::critical!(
+                "Could not create WasmInstance from valid module with context: {}",
+                err
+            )
         })
     }
 
@@ -482,10 +468,7 @@ impl<C: Blockchain> MatchstickInstance<C> {
         let gas = gas.cheap_clone();
         linker.func("gas", "gas", move |gas_used: u32| -> Result<(), Trap> {
             if let Err(e) = gas.consume_host_fn(gas_used.saturating_into()) {
-                panic!(
-                    "{}",
-                    Log::Critical(format!("Could not link gas function: {}", e)),
-                );
+                logging::critical!("Could not link gas function: {}", e)
             }
 
             Ok(())

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -19,6 +19,7 @@ pub fn clear_indent() {
 /// Whether to accumulate the logs or print them as they come.
 static mut ACCUM: bool = false;
 pub(crate) static mut LOGS: Vec<String> = vec![];
+
 /// Start accumulating the logs instead of printing them directly.
 pub fn accum() {
     unsafe { ACCUM = true };
@@ -82,10 +83,82 @@ impl<T: fmt::Display> fmt::Display for Log<T> {
             Log::Error(s) => format!("𝖷 {}", s).bold().red(),
             Log::Warning(s) => format!("⚠️  {}", s).yellow(),
             Log::Info(s) => format!("💬 {}", s).italic(),
-            Log::Debug(s) => format!("🛠 {}", s).italic().cyan(),
+            Log::Debug(s) => format!("🛠  {}", s).italic().cyan(),
             Log::Success(s) => format!("√ {}", s).bold().green(),
             Log::Default(s) => format!("{}", s).normal(),
         };
         unsafe { write!(f, "{}{}", " ".repeat(INDENT), s) }
     }
 }
+
+#[macro_export]
+macro_rules! log {
+    ($log_level:literal, $log_string:expr) => ({
+        logging::Log::new($log_level, $log_string).println();
+    });
+
+    ($log_level:literal, $log_string:expr, $($arg:tt)*) => ({
+        logging::Log::new($log_level, format!($log_string, $($arg)*)).println();
+    });
+}
+
+macro_rules! log_with_color {
+    ($log_color:ident, $log_string:expr) => ({
+        $crate::log!(6, $log_string.$log_color())
+    });
+
+    ($log_color:ident, $log_string:literal, $($arg:tt)*) => ({
+        $crate::log!(6, format!($log_string, $($arg)*).$log_color())
+    });
+}
+
+// macro_rules! critical {
+//     ($($arg:tt)*) => ({
+//         $crate::log!(0, $($arg)*);
+//     });
+// }
+
+macro_rules! error {
+    ($($arg:tt)*) => ({
+        $crate::log!(1, $($arg)*);
+    });
+}
+
+macro_rules! warning {
+    ($($arg:tt)*) => ({
+        $crate::log!(2, $($arg)*);
+    });
+}
+
+macro_rules! info {
+    ($($arg:tt)*) => ({
+        $crate::log!(3, $($arg)*);
+    });
+}
+
+macro_rules! debug {
+    ($($arg:tt)*) => ({
+        $crate::log!(4, $($arg)*);
+    });
+}
+
+macro_rules! success {
+    ($($arg:tt)*) => ({
+        $crate::log!(5, $($arg)*);
+    });
+}
+
+macro_rules! default {
+    ($($arg:tt)*) => ({
+        $crate::log!(6, $($arg)*);
+    });
+}
+
+pub(crate) use log_with_color;
+// pub(crate) use critical;
+pub(crate) use debug;
+pub(crate) use default;
+pub(crate) use error;
+pub(crate) use info;
+pub(crate) use success;
+pub(crate) use warning;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -101,6 +101,10 @@ macro_rules! log {
     });
 }
 
+/// Prints the message formatted with the passed color identifier
+/// Accepts all colors available in the `colored` crate, e.g blue, bright_blue, red, bright_red, etc.
+/// log_with_color!(bright_red, "Some string")
+/// log_with_color!(green, "Some string {} {}", "with", "arguments")
 macro_rules! log_with_color {
     ($log_color:ident, $log_string:expr) => ({
         $crate::logging::log!(6, $log_string.$log_color())
@@ -111,6 +115,7 @@ macro_rules! log_with_color {
     });
 }
 
+/// This macro will panic instead of just printing the message
 macro_rules! critical {
     ($log_string:expr) => ({
         panic!("{}", $crate::logging::Log::Critical($log_string));
@@ -157,12 +162,4 @@ macro_rules! default {
     });
 }
 
-pub(crate) use critical;
-pub(crate) use debug;
-pub(crate) use default;
-pub(crate) use error;
-pub(crate) use info;
-pub(crate) use log;
-pub(crate) use log_with_color;
-pub(crate) use success;
-pub(crate) use warning;
+pub(crate) use {critical, debug, default, error, info, log, log_with_color, success, warning};

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -102,20 +102,21 @@ macro_rules! log {
 }
 
 /// Prints the message formatted with the passed color identifier
-/// Accepts all colors available in the `colored` crate, e.g blue, bright_blue, red, bright_red, etc.
-/// log_with_color!(bright_red, "Some string")
-/// log_with_color!(green, "Some string {} {}", "with", "arguments")
-macro_rules! log_with_color {
-    ($log_color:ident, $log_string:expr) => ({
-        $crate::logging::log!(6, $log_string.$log_color())
+/// Can accept multiple style options.
+/// log_with_style!(bright_red, "Hello world!")
+/// log_with_style!(bold, green, "Hello {}", "world!")
+/// log_with_style!(bold, blue, on_yellow, "{} {}", "Hello", "world!")
+macro_rules! log_with_style {
+    ($($log_style:ident,)+ $log_string:literal) => ({
+        $crate::logging::log!(6, $log_string$(.$log_style())+)
     });
 
-    ($log_color:ident, $log_string:literal, $($arg:tt)*) => ({
-        $crate::logging::log!(6, format!($log_string, $($arg)*).$log_color())
+    ($($log_style:ident,)+ $log_string:literal, $($arg:tt)*) => ({
+        $crate::logging::log!(6, format!($log_string, $($arg)*)$(.$log_style())+)
     });
 }
 
-/// This macro will panic instead of just printing the message
+/// This macro will panic
 macro_rules! critical {
     ($log_string:expr) => ({
         panic!("{}", $crate::logging::Log::Critical($log_string));
@@ -162,4 +163,4 @@ macro_rules! default {
     });
 }
 
-pub(crate) use {critical, debug, default, error, info, log, log_with_color, success, warning};
+pub(crate) use {critical, debug, default, error, info, log, log_with_style, success, warning};

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -113,11 +113,11 @@ macro_rules! log_with_color {
 
 macro_rules! critical {
     ($log_string:expr) => ({
-        panic!("{}", $crate::logging::Log::new(0, $log_string));
+        panic!("{}", $crate::logging::Log::Critical($log_string));
     });
 
     ($log_string:expr, $($arg:tt)*) => ({
-        panic!("{}", $crate::logging::Log::new(0, format!($log_string, $($arg)*)));
+        panic!("{}", $crate::logging::Log::Critical(format!($log_string, $($arg)*)));
     });
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 /// Controls the amount of indentation added and substracted.
 static MARGIN: usize = 2;
 /// Current indentation when logging.
-static mut INDENT: usize = 0;
+pub static mut INDENT: usize = 0;
 pub fn add_indent() {
     unsafe { INDENT += MARGIN };
 }
@@ -91,74 +91,78 @@ impl<T: fmt::Display> fmt::Display for Log<T> {
     }
 }
 
-#[macro_export]
 macro_rules! log {
-    ($log_level:literal, $log_string:expr) => ({
-        logging::Log::new($log_level, $log_string).println();
+    ($log_level:expr, $log_string:expr) => ({
+        $crate::logging::Log::new($log_level, $log_string).println();
     });
 
-    ($log_level:literal, $log_string:expr, $($arg:tt)*) => ({
-        logging::Log::new($log_level, format!($log_string, $($arg)*)).println();
+    ($log_level:expr, $log_string:expr, $($arg:tt)*) => ({
+        $crate::logging::Log::new($log_level, format!($log_string, $($arg)*)).println();
     });
 }
 
 macro_rules! log_with_color {
     ($log_color:ident, $log_string:expr) => ({
-        $crate::log!(6, $log_string.$log_color())
+        $crate::logging::log!(6, $log_string.$log_color())
     });
 
     ($log_color:ident, $log_string:literal, $($arg:tt)*) => ({
-        $crate::log!(6, format!($log_string, $($arg)*).$log_color())
+        $crate::logging::log!(6, format!($log_string, $($arg)*).$log_color())
     });
 }
 
-// macro_rules! critical {
-//     ($($arg:tt)*) => ({
-//         $crate::log!(0, $($arg)*);
-//     });
-// }
+macro_rules! critical {
+    ($log_string:expr) => ({
+        panic!("{}", $crate::logging::Log::new(0, $log_string));
+    });
+
+    ($log_string:expr, $($arg:tt)*) => ({
+        panic!("{}", $crate::logging::Log::new(0, format!($log_string, $($arg)*)));
+    });
+}
 
 macro_rules! error {
     ($($arg:tt)*) => ({
-        $crate::log!(1, $($arg)*);
+        $crate::logging::log!(1, $($arg)*);
     });
 }
 
 macro_rules! warning {
     ($($arg:tt)*) => ({
-        $crate::log!(2, $($arg)*);
+        $crate::logging::log!(2, $($arg)*);
     });
 }
 
 macro_rules! info {
     ($($arg:tt)*) => ({
-        $crate::log!(3, $($arg)*);
+        $crate::logging::log!(3, $($arg)*);
     });
 }
 
 macro_rules! debug {
     ($($arg:tt)*) => ({
-        $crate::log!(4, $($arg)*);
+        $crate::logging::log!(4, $($arg)*);
     });
 }
 
 macro_rules! success {
     ($($arg:tt)*) => ({
-        $crate::log!(5, $($arg)*);
+        $crate::logging::log!(5, $($arg)*);
     });
 }
 
 macro_rules! default {
     ($($arg:tt)*) => ({
-        $crate::log!(6, $($arg)*);
+        $crate::logging::log!(6, $($arg)*);
     });
 }
 
-pub(crate) use log_with_color;
-// pub(crate) use critical;
+pub(crate) use critical;
 pub(crate) use debug;
 pub(crate) use default;
 pub(crate) use error;
 pub(crate) use info;
+pub(crate) use log;
+pub(crate) use log_with_color;
 pub(crate) use success;
 pub(crate) use warning;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use graph_chain_ethereum::Chain;
 use crate::compiler::Compiler;
 use crate::config::MatchstickConfig;
 use crate::instance::MatchstickInstance;
-use crate::logging::Log;
 use crate::test_suite::{TestResult, TestSuite};
 
 use crate::coverage::generate_coverage_report;
@@ -48,7 +47,7 @@ fn main() {
     TESTS_LOCATION.with(|path| *path.borrow_mut() = PathBuf::from(&config.tests_path));
     LIBS_LOCATION.with(|path| *path.borrow_mut() = PathBuf::from(&config.libs_path));
 
-    Log::Default("Compiling...\n".to_owned().bright_green()).println();
+    logging::log_with_color!(bright_green, "Compiling...\n");
 
     let compiler = Compiler::new(PathBuf::from(config.libs_path))
         .export_table()
@@ -83,18 +82,18 @@ fn main() {
 
     let exit_code = run_test_suites(test_suites);
 
-    Log::Default(format!(
+    logging::default!(
         "\n[{}] Program executed in: {:.3?}.",
         Local::now().to_rfc2822(),
         now.elapsed()
-    ))
-    .println();
+    );
 
     std::process::exit(exit_code);
 }
 
 fn print_logo() {
-    Log::Default(
+    logging::log_with_color!(
+        bright_red,
         r#"
 ___  ___      _       _         _   _      _
 |  \/  |     | |     | |       | | (_)    | |
@@ -103,20 +102,18 @@ ___  ___      _       _         _   _      _
 | |  | | (_| | || (__| | | \__ \ |_| | (__|   <
 \_|  |_/\__,_|\__\___|_| |_|___/\__|_|\___|_|\_\
     "#
-        .bright_red(),
     )
-    .println()
 }
 
 fn run_test_suites(test_suites: HashMap<String, TestSuite>) -> i32 {
-    Log::Default("\nIgniting tests 🔥".bright_red()).println();
+    logging::log_with_color!(bright_red, "\nIgniting tests 🔥");
 
     let (mut num_passed, mut num_failed) = (0, 0);
     let failed_suites: HashMap<String, HashMap<String, TestResult>> = test_suites
         .into_iter()
         .filter_map(|(name, suite)| {
-            Log::Default(format!("\n{}", name).bold().bright_blue()).println();
-            Log::Default("-".repeat(50)).println();
+            logging::log_with_color!(bright_blue, "\n{}", name);
+            logging::default!("-".repeat(50));
 
             logging::add_indent();
             let failed: HashMap<String, TestResult> = suite
@@ -148,21 +145,22 @@ fn run_test_suites(test_suites: HashMap<String, TestSuite>) -> i32 {
         let passed = format!("{} passed", num_passed).green();
         let total = format!("{} total", num_failed + num_passed);
 
-        Log::Default("\nFailed tests:\n".red()).println();
+        logging::log_with_color!(red, "\nFailed tests:\n");
+
         for (suite, tests) in failed_suites {
             for (name, result) in tests {
-                Log::Default(format!("{} {}", suite.bright_blue(), name.red())).println();
+                logging::default!("{} {}", suite.bright_blue(), name.red());
 
                 if !result.logs.is_empty() {
-                    Log::Default(result.logs).println();
+                    logging::default!(result.logs);
                 }
             }
         }
 
-        Log::Default(format!("{}, {}, {}", failed, passed, total)).println();
+        logging::default!("{}, {}, {}", failed, passed, total);
         1
     } else {
-        Log::Default(format!("All {} tests passed! 😎", num_passed).green()).println();
+        logging::log_with_color!(green, format!("\nAll {} tests passed! 😎", num_passed));
         0
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
     TESTS_LOCATION.with(|path| *path.borrow_mut() = PathBuf::from(&config.tests_path));
     LIBS_LOCATION.with(|path| *path.borrow_mut() = PathBuf::from(&config.libs_path));
 
-    logging::log_with_color!(bright_green, "Compiling...\n");
+    logging::log_with_style!(bright_green, "Compiling...\n");
 
     let compiler = Compiler::new(PathBuf::from(config.libs_path))
         .export_table()
@@ -92,7 +92,7 @@ fn main() {
 }
 
 fn print_logo() {
-    logging::log_with_color!(
+    logging::log_with_style!(
         bright_red,
         r#"
 ___  ___      _       _         _   _      _
@@ -106,13 +106,13 @@ ___  ___      _       _         _   _      _
 }
 
 fn run_test_suites(test_suites: HashMap<String, TestSuite>) -> i32 {
-    logging::log_with_color!(bright_red, "\nIgniting tests 🔥");
+    logging::log_with_style!(bright_red, "\nIgniting tests 🔥");
 
     let (mut num_passed, mut num_failed) = (0, 0);
     let failed_suites: HashMap<String, HashMap<String, TestResult>> = test_suites
         .into_iter()
         .filter_map(|(name, suite)| {
-            logging::log_with_color!(bright_blue, "\n{}", name);
+            logging::log_with_style!(bright_blue, "\n{}", name);
             logging::default!("-".repeat(50));
 
             logging::add_indent();
@@ -145,7 +145,7 @@ fn run_test_suites(test_suites: HashMap<String, TestSuite>) -> i32 {
         let passed = format!("{} passed", num_passed).green();
         let total = format!("{} total", num_failed + num_passed);
 
-        logging::log_with_color!(red, "\nFailed tests:\n");
+        logging::log_with_style!(red, "\nFailed tests:\n");
 
         for (suite, tests) in failed_suites {
             for (name, result) in tests {
@@ -160,7 +160,7 @@ fn run_test_suites(test_suites: HashMap<String, TestSuite>) -> i32 {
         logging::default!("{}, {}, {}", failed, passed, total);
         1
     } else {
-        logging::log_with_color!(green, format!("\nAll {} tests passed! 😎", num_passed));
+        logging::log_with_style!(green, "\nAll {} tests passed! 😎", num_passed);
         0
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use serde_yaml::{Sequence, Value};
 use std::collections::HashMap;
 
-use crate::logging::Log;
+use crate::logging::{self, Log};
 
 /// Parses the yaml file
 /// If the parsing fails returns a serde Value containing an empty String
@@ -18,7 +18,7 @@ pub fn parse_yaml(path: &str) -> Value {
 
     // Print warning and return empty string Value if parsing fails
     serde_yaml::from_str(&yaml_content).unwrap_or_else(|_| {
-        Log::Warning(format!("{} is empty or contains invalid values!", path)).println();
+        logging::warning!("{} is empty or contains invalid values!", path);
         Value::String("".to_owned())
     })
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,18 +1,16 @@
 use serde_yaml::{Sequence, Value};
 use std::collections::HashMap;
 
-use crate::logging::{self, Log};
+use crate::logging;
 
 /// Parses the yaml file
 /// If the parsing fails returns a serde Value containing an empty String
 pub fn parse_yaml(path: &str) -> Value {
     let yaml_content = std::fs::read_to_string(path).unwrap_or_else(|err| {
-        panic!(
-            "{}",
-            Log::Critical(format!(
-                "Something went wrong while trying to read `{}`: {}",
-                path, err,
-            )),
+        logging::critical!(
+            "Something went wrong while trying to read `{}`: {}",
+            path,
+            err,
         )
     });
 

--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -3,10 +3,7 @@ use graph::blockchain::Blockchain;
 use std::time::Instant;
 use wasmtime::Func;
 
-use crate::{
-    instance::MatchstickInstance,
-    logging::{self, Log},
-};
+use crate::{instance::MatchstickInstance, logging};
 
 pub struct Test {
     pub name: String,
@@ -35,10 +32,7 @@ impl Test {
     fn call_hooks(hooks: &[Func]) {
         hooks.iter().for_each(|h| {
             h.call(&[]).unwrap_or_else(|err| {
-                panic!(
-                    "{}",
-                    Log::Critical(format!("Unexpected error upon calling hook: {}", err)),
-                );
+                logging::critical!("Unexpected error upon calling hook: {}", err)
             });
         });
     }
@@ -122,13 +116,10 @@ pub struct TestSuite {
 impl<C: Blockchain> From<&MatchstickInstance<C>> for TestSuite {
     fn from(matchstick: &MatchstickInstance<C>) -> Self {
         let table = matchstick.instance.get_table("table").unwrap_or_else(|| {
-            panic!(
-                "{}",
-                Log::Critical(
-                    "WebAssembly.Table was not exported from the AssemblyScript sources.
+            logging::critical!(
+                "WebAssembly.Table was not exported from the AssemblyScript sources.
                     (Please compile with the `--exportTable` option.)"
-                ),
-            );
+            )
         });
 
         let mut suite = TestSuite { tests: vec![] };
@@ -137,10 +128,7 @@ impl<C: Blockchain> From<&MatchstickInstance<C>> for TestSuite {
             .borrow()
             .as_ref()
             .unwrap_or_else(|| {
-                panic!(
-                    "{}",
-                    Log::Critical("Unexpected: MatchstickInstanceContext is 'None'."),
-                );
+                logging::critical!("Unexpected: MatchstickInstanceContext is 'None'.")
             })
             .meta_tests
         {
@@ -150,13 +138,10 @@ impl<C: Blockchain> From<&MatchstickInstance<C>> for TestSuite {
                 table
                     .get(*func_idx)
                     .unwrap_or_else(|| {
-                        panic!(
-                            "{}",
-                            Log::Critical(format!(
-                                "Could not get WebAssembly.Table entry with index '{}'.",
-                                func_idx,
-                            )),
-                        );
+                        logging::critical!(
+                            "Could not get WebAssembly.Table entry with index '{}'.",
+                            func_idx,
+                        )
                     })
                     .unwrap_funcref()
                     .unwrap()

--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -66,7 +66,7 @@ impl Test {
                 // Log error and mark test as failed if should_fail is `true`, but test passes
                 // Otherwise mark test as passed
                 if self.should_fail {
-                    Log::Error("Expected test to fail but it passed successfully!").println();
+                    logging::error!("Expected test to fail but it passed successfully!");
                     false
                 } else {
                     true
@@ -79,7 +79,7 @@ impl Test {
                     true
                 } else {
                     logging::add_indent();
-                    Log::Debug(err).println();
+                    logging::debug!(err);
                     logging::sub_indent();
                     false
                 }
@@ -99,17 +99,18 @@ impl Test {
             format!("{:.3?}ms", elapsed_in_ms).bright_blue()
         );
         if passed {
-            Log::Success(msg).println();
+            logging::success!(msg);
         } else {
-            Log::Error(msg).println();
+            logging::error!(msg);
         }
 
         // Print the logs after the test result.
         if passed && !logs.is_empty() {
-            Log::Default(&logs).println();
+            logging::default!(&logs);
         }
 
         self.after();
+
         TestResult { passed, logs }
     }
 }


### PR DESCRIPTION
closes https://github.com/LimeChain/matchstick/issues/290
____________________________________________________________________

Adds logging macros:
 - log!
 - log_with_style!
 - critical!
 - debug!
 - default!
 - error!
 - info!
 - success!
 - warning!
 
#### Examples:
```
log!(log_level, "Hello World!")
log!(log_level, "Hello {}", "World")
```
log_level should mach one of the levels declared in [logging](https://github.com/LimeChain/matchstick/blob/main/src/logging.rs#L54-L60)
____________________________________________________________________

```
log_with_style!(green, "Hello world!")
log_with_style!(bold, green, "Hello {}", "world!")
log_with_style!(bold, green, on_white, "{} {}", "Hello", "world!")
```
<img width="234" alt="Screenshot 2022-02-22 at 12 43 10" src="https://user-images.githubusercontent.com/20456492/155116316-fc0575ec-e94b-4c06-8b50-4e25c9140c4a.png">

Accepts all styles available in https://docs.rs/colored/2.0.0/colored/trait.Colorize.html
____________________________________________________________________

```
critical!("Will panic!")
critical!("Will {}", "panic!")
```
____________________________________________________________________

The rest of the macros have the same syntax as `critical!` and will print the message in the formatting of the corresponding log level