### PR TITLE
Fix negative not being handled correctly

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -8,11 +8,11 @@ use graph::{
     blockchain::Blockchain,
     data::{
         graphql::ext::DirectiveFinder,
-        store::{Attribute, Value},
+        store::{scalar::Bytes, Attribute, Value},
     },
     prelude::{
         ethabi::{Address, ParamType, Token},
-        Entity,
+        BigInt, Entity,
     },
     runtime::{asc_get, asc_new, gas::GasCounter, try_asc_get, AscPtr, HostExportError},
     semver::Version,
@@ -260,14 +260,18 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
             &GasCounter::new(),
         )?;
 
-        if expected != actual {
+        let exp_val = get_token_value(expected);
+        let act_val = get_token_value(actual);
+
+        if exp_val != act_val {
             logging::error!(
-                "(assert.equals) Expected value was '{:?}' but actual value was '{:?}'",
-                expected,
-                actual
+                "(assert.equals) Expected value was '{}' but actual value was '{}'",
+                exp_val,
+                act_val
             );
             return Ok(false);
         }
+
         Ok(true)
     }
 
@@ -1132,5 +1136,21 @@ fn get_kind(kind: String) -> ParamType {
             ParamType::Tuple(components)
         }
         _ => logging::critical!("Unrecognized argument type `{}`", kind_str),
+    }
+}
+
+fn get_token_value(token: Token) -> Value {
+    match token {
+        Token::Address(address) => Value::Bytes(Bytes::from(address)),
+        Token::FixedBytes(bytes) | Token::Bytes(bytes) => {
+            Value::Bytes(Bytes::from(bytes.as_slice()))
+        }
+        Token::Int(uint) => Value::BigInt(BigInt::from_signed_u256(&uint)),
+        Token::Uint(uint) => Value::BigInt(BigInt::from_unsigned_u256(&uint)),
+        Token::Bool(bool) => Value::Bool(bool),
+        Token::String(string) => Value::String(string),
+        Token::FixedArray(tokens) | Token::Array(tokens) | Token::Tuple(tokens) => {
+            Value::List(tokens.into_iter().map(get_token_value).collect())
+        }
     }
 }


### PR DESCRIPTION
Convert ethabi::Token to store::Value. This allows to properly display the actual negative numbers instead of overflowed u256 `Int(115792089237316195423570985008687907853269984665640564039457584007910982156288)`, because ehtabi::Token holds uin256 type for Token::Int value