### PR TITLE
fix: allow multiple entities to point to the same derived entity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchstick"
-version = "0.4.2"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchstick"
-version = "0.4.2"
+version = "0.4.4"
 authors = ["LimeChain <limechain.tech>"]
 edition = "2021"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{App, Arg};
 
 pub fn initialize() -> App<'static, 'static> {
     App::new("Matchstick 🔥")
-        .version("0.4.2")
+        .version("0.4.4")
         .author("Limechain <https://limechain.tech>")
         .about("Unit testing framework for Subgraph development on The Graph protocol.")
         .arg(

--- a/src/context.rs
+++ b/src/context.rs
@@ -390,15 +390,8 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 })
                 .clone();
             for linking_field in linking_fields {
-                let mut derived_entity_type:Option<String> = None;
-                let rel_vec = self.derived.get(&entity_type).unwrap().clone();
-                let rel_iter = rel_vec.iter();
-                for val in rel_iter {
-                    if val.0 == linking_field.0 && val.1 == linking_field.1 {
-                        derived_entity_type = Some(String::from(&val.2));
-                    }
-                }
-                if let Some(original_entity_type) = &derived_entity_type {
+                if self.store.contains_key(&linking_field.2) {
+                    let original_entity_type = linking_field.2.to_string();
                     if data.contains_key(&linking_field.1) {
                         let derived_field_value = data
                             .get(&linking_field.1)
@@ -524,19 +517,11 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                                 )
                             })
                             .clone();
-                        for linking_field in &linking_fields {
-                            let mut derived_entity_type:Option<String> = None;
-                            let mut inner_store = self.store.get(&entity_type).unwrap().clone();
+                        for linking_field in linking_fields.iter() {
                             let relation_id = data.get(&linking_field.1).unwrap();
-                            let rel_vec = self.derived.get(&entity_type).unwrap().clone();
-                            let rel_iter = rel_vec.iter();
-                            for val in rel_iter {
-                                if val.0 == linking_field.0 && val.1 == linking_field.1 && self.store.contains_key(&val.2) {
-                                    inner_store = self.store.get(&val.2).unwrap().clone();
-                                    derived_entity_type = Some(String::from(&val.2))
-                                }
-                            }
-                            if let Some(original_entity_type) = &derived_entity_type {
+                            if self.store.contains_key(&linking_field.2) {
+                                let original_entity_type = linking_field.2.to_string();
+                                let inner_store = self.store.get(&String::from(&original_entity_type)).unwrap().clone();
                                 if relation_id.is_string()
                                     && inner_store.contains_key(relation_id.as_str().unwrap())
                                 {
@@ -558,7 +543,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                                                     relation_id,
                                                     field,
                                                     id.clone(),
-                                                    original_entity_type.clone(),
+                                                    original_entity_type.to_string(),
                                                     entity_deleted,
                                                 );
                                             }
@@ -571,18 +556,10 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                         // Removes the entity with no relations from every list it may be in
                         if entity_deleted {
                             for linking_field in &linking_fields {
-                                let mut derived_entity_type:Option<String> = None;
-                                let mut inner_store = self.store.get(&entity_type).unwrap().clone();
                                 let relation_id = data.get(&linking_field.1).unwrap();
-                                let rel_vec = self.derived.get(&entity_type.clone()).unwrap().clone();
-                                let rel_iter = rel_vec.iter();
-                                for val in rel_iter {
-                                    if val.0 == linking_field.0 && val.1 == linking_field.1 && self.store.contains_key(&val.2) {
-                                        derived_entity_type = Some(String::from(&val.2));
-                                        inner_store = self.store.get(&val.2).unwrap().clone();
-                                    }
-                                }
-                                if let Some(original_entity_type) = &derived_entity_type {
+                                if self.store.contains_key(&linking_field.2) {
+                                    let original_entity_type = linking_field.2.to_string();
+                                    let inner_store = self.store.get(&String::from(&original_entity_type)).unwrap().clone();
                                     if relation_id.is_string() {
                                         for original_entity_id_and_data in &inner_store {
                                             let innermost_store = inner_store
@@ -750,16 +727,9 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
             .clone();
 
         for linking_field in linking_fields {
-            let mut derived_entity_type:Option<String> = None;
-            let rel_vec = self.derived.get(&entity_type.clone()).unwrap().clone();
-            let rel_iter = rel_vec.iter();
-            for val in rel_iter {
-                if val.0 == linking_field.0 && val.1 == linking_field.1 && self.store.contains_key(&val.2) {
-                    derived_entity_type = Some(String::from(&val.2));
-                }
-            }
-            if let Some(original_entity_type) = &derived_entity_type {
-                let mut original_entity = store.get(original_entity_type).unwrap().clone();
+            if self.store.contains_key(&linking_field.2) {
+                let original_entity_type = linking_field.2.to_string();
+                let mut original_entity = store.get(&original_entity_type).unwrap().clone();
                 if deleted_entity_data.contains_key(&linking_field.1) {
                     let relation_id = deleted_entity_data.get(&linking_field.1).unwrap();
                     if relation_id.is_string()

--- a/src/context.rs
+++ b/src/context.rs
@@ -393,7 +393,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 if self.store.contains_key(&linking_field.2) 
                     && data.contains_key(&linking_field.1) 
                 {
-                    let original_entity_type = linking_field.2.to_string();
+                    let original_entity_type = linking_field.2.clone();
                     let derived_field_value = data
                         .get(&linking_field.1)
                         .unwrap_or_else(|| {
@@ -517,11 +517,11 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                                 )
                             })
                             .clone();
-                        for linking_field in linking_fields.iter() {
-                            let relation_id = data.get(&linking_field.1).unwrap();
+                        for linking_field in &linking_fields {
                             if self.store.contains_key(&linking_field.2) {
-                                let original_entity_type = linking_field.2.to_string();
+                                let original_entity_type = linking_field.2.clone();
                                 let inner_store = self.store.get(&String::from(&original_entity_type)).unwrap().clone();
+                                let relation_id = data.get(&linking_field.1).unwrap();
                                 if relation_id.is_string()
                                     && inner_store.contains_key(relation_id.as_str().unwrap())
                                 {
@@ -543,7 +543,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                                                     relation_id,
                                                     field,
                                                     id.clone(),
-                                                    original_entity_type.to_string(),
+                                                    original_entity_type.clone(),
                                                     entity_deleted,
                                                 );
                                             }
@@ -556,10 +556,10 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                         // Removes the entity with no relations from every list it may be in
                         if entity_deleted {
                             for linking_field in &linking_fields {
-                                let relation_id = data.get(&linking_field.1).unwrap();
                                 if self.store.contains_key(&linking_field.2) {
-                                    let original_entity_type = linking_field.2.to_string();
+                                    let original_entity_type = linking_field.2.clone();
                                     let inner_store = self.store.get(&String::from(&original_entity_type)).unwrap().clone();
+                                    let relation_id = data.get(&linking_field.1).unwrap();
                                     if relation_id.is_string() {
                                         for original_entity_id_and_data in &inner_store {
                                             let innermost_store = inner_store
@@ -728,7 +728,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
 
         for linking_field in linking_fields {
             if self.store.contains_key(&linking_field.2) {
-                let original_entity_type = linking_field.2.to_string();
+                let original_entity_type = linking_field.2.clone();
                 let mut original_entity = store.get(&original_entity_type).unwrap().clone();
                 if deleted_entity_data.contains_key(&linking_field.1) {
                     let relation_id = deleted_entity_data.get(&linking_field.1).unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -390,7 +390,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 })
                 .clone();
             for linking_field in linking_fields {
-                if self.store.contains_key(&linking_field.2) && data.contains_key(&linking_field.1)
+                if data.contains_key(&linking_field.1) && self.store.contains_key(&linking_field.2)
                 {
                     let original_entity_type = linking_field.2.clone();
                     let derived_field_value = data
@@ -518,12 +518,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                             .clone();
                         for linking_field in &linking_fields {
                             if self.store.contains_key(&linking_field.2) {
-                                let original_entity_type = linking_field.2.clone();
-                                let inner_store = self
-                                    .store
-                                    .get(&String::from(&original_entity_type))
-                                    .unwrap()
-                                    .clone();
+                                let inner_store = self.store.get(&linking_field.2).unwrap().clone();
                                 let relation_id = data.get(&linking_field.1).unwrap();
                                 if relation_id.is_string()
                                     && inner_store.contains_key(relation_id.as_str().unwrap())
@@ -546,7 +541,6 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                                                     relation_id,
                                                     field,
                                                     id.clone(),
-                                                    original_entity_type.clone(),
                                                     entity_deleted,
                                                 );
                                             }
@@ -560,12 +554,8 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                         if entity_deleted {
                             for linking_field in &linking_fields {
                                 if self.store.contains_key(&linking_field.2) {
-                                    let original_entity_type = linking_field.2.clone();
-                                    let inner_store = self
-                                        .store
-                                        .get(&String::from(&original_entity_type))
-                                        .unwrap()
-                                        .clone();
+                                    let inner_store =
+                                        self.store.get(&linking_field.2).unwrap().clone();
                                     let relation_id = data.get(&linking_field.1).unwrap();
                                     if relation_id.is_string() {
                                         for original_entity_id_and_data in &inner_store {
@@ -589,7 +579,6 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                                                             relation_id,
                                                             field,
                                                             id.clone(),
-                                                            original_entity_type.clone(),
                                                             entity_deleted,
                                                         );
                                                     }
@@ -615,7 +604,6 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         relation_id: &Value,
         field: (&String, &Value),
         id: String,
-        original_entity_type: String,
         entity_deleted: bool,
     ) {
         if data.get(&linking_field.1).unwrap().is_string() {
@@ -624,7 +612,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 relation_id.as_str().unwrap(),
                 field,
                 Value::String(id),
-                original_entity_type,
+                linking_field.2.clone(),
                 entity_deleted,
             );
         } else if matches!(data.get(&linking_field.1).unwrap(), Value::List(_)) {
@@ -640,7 +628,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                     relation_id.as_str().unwrap(),
                     field,
                     Value::String(id.clone()),
-                    original_entity_type.clone(),
+                    linking_field.2.clone(),
                     entity_deleted,
                 );
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -390,28 +390,21 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 })
                 .clone();
             for linking_field in linking_fields {
-                if self.store.contains_key(&linking_field.2) {
+                if self.store.contains_key(&linking_field.2) 
+                    && data.contains_key(&linking_field.1) 
+                {
                     let original_entity_type = linking_field.2.to_string();
-                    if data.contains_key(&linking_field.1) {
-                        let derived_field_value = data
-                            .get(&linking_field.1)
-                            .unwrap_or_else(|| {
-                                logging::critical!(
-                                    "Couldn't find value for {} in submitted data",
-                                    linking_field.1
-                                )
-                            })
-                            .clone();
-                        if matches!(derived_field_value, Value::List(_)) {
-                            for derived_field_value in derived_field_value.as_list().unwrap().clone() {
-                                self.insert_derived_field_in_store(
-                                    derived_field_value,
-                                    original_entity_type.clone(),
-                                    linking_field.clone(),
-                                    id.clone(),
-                                );
-                            }
-                        } else {
+                    let derived_field_value = data
+                        .get(&linking_field.1)
+                        .unwrap_or_else(|| {
+                            logging::critical!(
+                                "Couldn't find value for {} in submitted data",
+                                linking_field.1
+                            )
+                        })
+                        .clone();
+                    if matches!(derived_field_value, Value::List(_)) {
+                        for derived_field_value in derived_field_value.as_list().unwrap().clone() {
                             self.insert_derived_field_in_store(
                                 derived_field_value,
                                 original_entity_type.clone(),
@@ -419,6 +412,13 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                                 id.clone(),
                             );
                         }
+                    } else {
+                        self.insert_derived_field_in_store(
+                            derived_field_value,
+                            original_entity_type.clone(),
+                            linking_field.clone(),
+                            id.clone(),
+                        );
                     }
                 }
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -76,7 +76,7 @@ pub struct MatchstickInstanceContext<C: Blockchain> {
     /// Holding the derived field type and a tuple of the entity it points to
     /// with a vector of all the field names and the corresponding derived field names.
     /// The example below is taken from a schema.graphql file and will fill the map in the following way:
-    /// {"NameSignalTransaction": ("GraphAccount", [("nameSignalTransactions", "signer")])}
+    /// {"NameSignalTransaction": [("nameSignalTransactions", "signer", "GraphAccount")])}
     /// ```
     /// type GraphAccount @entity {
     ///     id: ID!
@@ -596,7 +596,6 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn handle_different_value_types(
         &mut self,
         data: HashMap<String, Value>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -390,8 +390,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 })
                 .clone();
             for linking_field in linking_fields {
-                if self.store.contains_key(&linking_field.2) 
-                    && data.contains_key(&linking_field.1) 
+                if self.store.contains_key(&linking_field.2) && data.contains_key(&linking_field.1)
                 {
                     let original_entity_type = linking_field.2.clone();
                     let derived_field_value = data
@@ -520,7 +519,11 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                         for linking_field in &linking_fields {
                             if self.store.contains_key(&linking_field.2) {
                                 let original_entity_type = linking_field.2.clone();
-                                let inner_store = self.store.get(&String::from(&original_entity_type)).unwrap().clone();
+                                let inner_store = self
+                                    .store
+                                    .get(&String::from(&original_entity_type))
+                                    .unwrap()
+                                    .clone();
                                 let relation_id = data.get(&linking_field.1).unwrap();
                                 if relation_id.is_string()
                                     && inner_store.contains_key(relation_id.as_str().unwrap())
@@ -558,7 +561,11 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                             for linking_field in &linking_fields {
                                 if self.store.contains_key(&linking_field.2) {
                                     let original_entity_type = linking_field.2.clone();
-                                    let inner_store = self.store.get(&String::from(&original_entity_type)).unwrap().clone();
+                                    let inner_store = self
+                                        .store
+                                        .get(&String::from(&original_entity_type))
+                                        .unwrap()
+                                        .clone();
                                     let relation_id = data.get(&linking_field.1).unwrap();
                                     if relation_id.is_string() {
                                         for original_entity_id_and_data in &inner_store {
@@ -1156,7 +1163,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                         .1
                         .to_string()
                         .replace('\"', "");
-                    
+
                     if self.derived.contains_key(&clean_field_type) {
                         let mut field_names_vec = self
                             .derived
@@ -1169,24 +1176,15 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                             })
                             .clone();
 
-                        let field_names_tuple = (
-                            f.name.clone(),
-                            field,
-                            String::from(entity_type)
-                        );
+                        let field_names_tuple = (f.name.clone(), field, String::from(entity_type));
                         if !field_names_vec.contains(&field_names_tuple) {
                             field_names_vec.push(field_names_tuple);
-                            self.derived
-                                .insert(clean_field_type, field_names_vec);
+                            self.derived.insert(clean_field_type, field_names_vec);
                         }
                     } else {
                         self.derived.insert(
                             clean_field_type,
-                            vec![(
-                                f.name.clone(),
-                                field,
-                                String::from(entity_type)
-                            )],
+                            vec![(f.name.clone(), field, String::from(entity_type))],
                         );
                     }
                 }

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -607,10 +607,7 @@ mod unit_tests {
         context.store.insert("GraphAccount".to_owned(), inner_map);
         context.derived.insert(
             "NameSignalTransaction".to_owned(),
-            (
-                "GraphAccount".to_owned(),
-                vec![("nameSignalTransactions".to_owned(), "signer".to_owned())],
-            ),
+            vec![("nameSignalTransactions".to_owned(), "signer".to_owned(), "GraphAccount".to_owned())],
         );
 
         let payload = AscEnum::<StoreValueKind> {

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -607,7 +607,11 @@ mod unit_tests {
         context.store.insert("GraphAccount".to_owned(), inner_map);
         context.derived.insert(
             "NameSignalTransaction".to_owned(),
-            vec![("nameSignalTransactions".to_owned(), "signer".to_owned(), "GraphAccount".to_owned())],
+            vec![(
+                "nameSignalTransactions".to_owned(),
+                "signer".to_owned(),
+                "GraphAccount".to_owned(),
+            )],
         );
 
         let payload = AscEnum::<StoreValueKind> {


### PR DESCRIPTION
Enables multiple entities to be `@derivedFrom` the same `@entity` by:

- packing the `TypeDefinition.name` into the `self.derived` tuple vector in `src/context.rs` 
- iterating on the vector for a match before carrying out any derived entity lookups

Closes: #333

_Updates the tests to match the altered definition_
