### PR TITLE
fix: postgres installation on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,15 @@ The release binary comes in two flavours - for **МacOS** and **Linux**. To add 
 
 #### MacOS 
 ❗ Postgres installation command:
+
 ```
-brew install postgresql
+brew install postgresql@14
+```
+
+Then create new symlink to the lib:
+
+```
+ln -sf /usr/local/opt/postgresql@14/lib/postgresql@14/libpq.5.dylib /usr/local/opt/postgresql/lib/libpq.5.dylib
 ```
 
 #### Linux 🐧


### PR DESCRIPTION
- `postgresql` formula is no longer available, user need to add the version such as `postgresql@14`
- The `libpq.5.dylib` is installed on `/usr/local/opt/postgresql@14/lib/postgresql@14/libpq.5.dylib` by default and it will break the `graph test`

```sh
❯ npx graph test -l
OS type: Darwin
OS arch: x64
OS release: 21.6.0
OS major version: 21
CPU model: Apple M1
Download link: https://github.com/LimeChain/matchstick/releases/download/0.5.3/binary-macos-11
Downloading release from https://github.com/LimeChain/matchstick/releases/download/0.5.3/binary-macos-11
binary-macos-11 has been installed!
dyld[12627]: Library not loaded: '/usr/local/opt/postgresql/lib/libpq.5.dylib'
  Referenced from: '/Users/pyk/github/risedle/monorepo/node_modules/binary-install-raw/bin/0.5.3/binary-macos-11'
  Reason: tried: '/usr/local/opt/postgresql/lib/libpq.5.dylib' (no such file), '/usr/local/lib/libpq.5.dylib' (no such file), '/usr/lib/libpq.5.dylib' (no such file)
```

Symlink solve the problem
