### PR TITLE
Implement `loadInBlock` method

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.68.0
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -34,7 +34,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.68.0
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -48,7 +48,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.68.0
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
@@ -64,7 +64,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.68.0
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1

--- a/src/context/derived_fields.rs
+++ b/src/context/derived_fields.rs
@@ -7,18 +7,17 @@ use crate::logging;
 
 /// This function checks whether all the necessary data is present in the store to avoid linking
 /// entities to other non existent entities which may cause serious collision problems later
-pub(crate) fn insert_derived_field_in_store<C: graph::blockchain::Blockchain>(
-    context: &mut MatchstickInstanceContext<C>,
+pub(crate) fn insert_derived_field_in_store(
+    store: &mut HashMap<String, HashMap<String, HashMap<String, Value>>>,
     derived_field_value: Value,
     original_entity: String,
     linking_field: (String, String, String),
-    id: String,
+    id: String
 ) {
     if derived_field_value.is_string() {
         let derived_field_string_value = derived_field_value.as_string().unwrap();
-        if context.store.contains_key(&original_entity) {
-            let mut inner_store = context
-                .store
+        if store.contains_key(&original_entity) {
+            let mut inner_store = store
                 .get(&original_entity)
                 .unwrap_or_else(|| {
                     logging::critical!("Couldn't find value for {} in store", original_entity)
@@ -59,7 +58,7 @@ pub(crate) fn insert_derived_field_in_store<C: graph::blockchain::Blockchain>(
                 }
                 inner_store.insert(derived_field_string_value, innermost_store);
             }
-            context.store.insert(original_entity, inner_store);
+            store.insert(original_entity, inner_store);
         }
     }
 }

--- a/src/context/derived_fields.rs
+++ b/src/context/derived_fields.rs
@@ -8,7 +8,7 @@ use crate::logging;
 /// This function checks whether all the necessary data is present in the store to avoid linking
 /// entities to other non existent entities which may cause serious collision problems later
 pub(crate) fn insert_derived_field_in_store(
-    store: &mut HashMap<String, HashMap<String, HashMap<String, Value>>>,
+    store: &mut super::Store,
     derived_field_value: Value,
     original_entity: String,
     linking_field: (String, String, String),

--- a/src/context/derived_fields.rs
+++ b/src/context/derived_fields.rs
@@ -12,7 +12,7 @@ pub(crate) fn insert_derived_field_in_store(
     derived_field_value: Value,
     original_entity: String,
     linking_field: (String, String, String),
-    id: String
+    id: String,
 ) {
     if derived_field_value.is_string() {
         let derived_field_string_value = derived_field_value.as_string().unwrap();

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -356,13 +356,11 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         entity_type_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
         _gas: &GasCounter,
-    )  -> Result<AscPtr<AscEntity>, HostExportError> {
+    ) -> Result<AscPtr<AscEntity>, HostExportError> {
         let entity_type: String = asc_get(&self.wasm_ctx, entity_type_ptr, &GasCounter::new())?;
         let id: String = asc_get(&self.wasm_ctx, id_ptr, &GasCounter::new())?;
 
-        if store.contains_key(&entity_type)
-            && store.get(&entity_type).unwrap().contains_key(&id)
-        {
+        if store.contains_key(&entity_type) && store.get(&entity_type).unwrap().contains_key(&id) {
             let entities = store.get(&entity_type).unwrap();
             let entity = entities.get(&id).unwrap().clone();
             let entity = Entity::from(entity);
@@ -382,8 +380,8 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         id_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscEntity>, HostExportError> {
         update_derived_relations_in_store(self);
-        
-        return self.get_store_entity(self.store.clone(), entity_type_ptr, id_ptr, _gas)
+
+        return self.get_store_entity(self.store.clone(), entity_type_ptr, id_ptr, _gas);
     }
 
     /// function store.getInBlock(entityType: string, id: string): Entity
@@ -392,7 +390,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         _gas: &GasCounter,
         entity_type_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
-    )  -> Result<AscPtr<AscEntity>, HostExportError> {
+    ) -> Result<AscPtr<AscEntity>, HostExportError> {
         return self.get_store_entity(self.cache_store.clone(), entity_type_ptr, id_ptr, _gas);
     }
 
@@ -460,8 +458,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                 })
                 .clone();
             for linking_field in linking_fields {
-                if data.contains_key(&linking_field.1) && store.contains_key(&linking_field.2)
-                {
+                if data.contains_key(&linking_field.1) && store.contains_key(&linking_field.2) {
                     let original_entity_type = linking_field.2.clone();
                     let derived_field_value = data
                         .get(&linking_field.1)
@@ -479,7 +476,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                                 derived_field_value,
                                 original_entity_type.clone(),
                                 linking_field.clone(),
-                                id.clone()
+                                id.clone(),
                             );
                         }
                     } else {
@@ -488,7 +485,7 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
                             derived_field_value,
                             original_entity_type.clone(),
                             linking_field.clone(),
-                            id.clone()
+                            id.clone(),
                         );
                     }
                 }
@@ -563,14 +560,9 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         id_ptr: AscPtr<AscString>,
         data_ptr: AscPtr<AscEntity>,
     ) -> Result<(), HostExportError> {
-
-        let updated_store = self.update_store(
-            self.store.clone(),
-            entity_type_ptr,
-            id_ptr,
-            data_ptr,
-            _gas
-        ).unwrap();
+        let updated_store = self
+            .update_store(self.store.clone(), entity_type_ptr, id_ptr, data_ptr, _gas)
+            .unwrap();
 
         self.store = updated_store;
         self.store_updated = false;
@@ -586,13 +578,15 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         id_ptr: AscPtr<AscString>,
         data_ptr: AscPtr<AscEntity>,
     ) -> Result<(), HostExportError> {
-        let updated_store = self.update_store(
-            self.cache_store.clone(),
-            entity_type_ptr,
-            id_ptr,
-            data_ptr,
-            _gas
-        ).unwrap();
+        let updated_store = self
+            .update_store(
+                self.cache_store.clone(),
+                entity_type_ptr,
+                id_ptr,
+                data_ptr,
+                _gas,
+            )
+            .unwrap();
 
         self.cache_store = updated_store;
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -577,10 +577,13 @@ impl<C: Blockchain> MatchstickInstanceContext<C> {
         id_ptr: AscPtr<AscString>,
         data_ptr: AscPtr<AscEntity>,
     ) -> Result<(), HostExportError> {
-        self.update_store(StoreScope::Global, entity_type_ptr, id_ptr, data_ptr, _gas);
-        self.store_updated = false;
+        let result = self.update_store(StoreScope::Global, entity_type_ptr, id_ptr, data_ptr, _gas);
 
-        Ok(())
+        if result.is_ok() {
+            self.store_updated = false;
+        }
+
+        result
     }
 
     /// function mockInBlockStore(entityType: string, id: string, data: map): void

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,5 +1,4 @@
-use std::borrow::BorrowMut;
-use std::{collections::HashMap, borrow::Borrow};
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context};

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -305,11 +305,19 @@ impl<C: Blockchain> MatchstickInstance<C> {
         );
 
         link!("clearStore", clear_store,);
+        link!("clearCacheStore", clear_cache_store,);
         link!("logStore", log_store,);
         link!(
             "store.get",
             mock_store_get,
             "host_export_store_get",
+            entity,
+            id
+        );
+        link!(
+            "store.get_in_block",
+            mock_store_get_in_block,
+            "host_export_store_get_in_block",
             entity,
             id
         );
@@ -322,6 +330,15 @@ impl<C: Blockchain> MatchstickInstance<C> {
             data
         );
         link!("store.remove", mock_store_remove, entity_ptr, id_ptr);
+
+        link!(
+            "addEntityToCacheStore",
+            cache_store_set,
+            "host_export_cache_store_set",
+            entity,
+            id,
+            data
+        );
 
         link!("mockIpfsFile", mock_ipfs_file, hash, file_path);
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -305,7 +305,7 @@ impl<C: Blockchain> MatchstickInstance<C> {
         );
 
         link!("clearStore", clear_store,);
-        link!("clearCacheStore", clear_cache_store,);
+        link!("clearInBlockStore", clear_cache_store,);
         link!("logStore", log_store,);
         link!(
             "store.get",
@@ -332,7 +332,7 @@ impl<C: Blockchain> MatchstickInstance<C> {
         link!("store.remove", mock_store_remove, entity_ptr, id_ptr);
 
         link!(
-            "addEntityToCacheStore",
+            "mockInBlockStore",
             cache_store_set,
             "host_export_cache_store_set",
             entity,

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -13,7 +13,7 @@ mod tests {
     use graph_chain_ethereum::{runtime::abi::AscUnresolvedContractCall_0_0_4, Chain};
     use graph_runtime_wasm::asc_abi::class::{
         Array, AscEnum, AscTypedMap, AscTypedMapEntry, EnumPayload, EthereumValueKind,
-        StoreValueKind, TypedArray,
+        StoreValueKind, TypedArray, AscString,
     };
     use serial_test::serial;
 
@@ -87,6 +87,20 @@ mod tests {
             .expect("Couldn't call clear_store");
 
         assert_eq!(context.store.len(), 0);
+    }
+
+    #[test]
+    #[serial]
+    fn clear_cache_store_basic_test() {
+        let mut context = get_context();
+
+        context.cache_store.insert("type".to_owned(), HashMap::new());
+
+        context
+            .clear_cache_store(&GasCounter::new())
+            .expect("Couldn't call clear_store");
+
+        assert_eq!(context.cache_store.len(), 0);
     }
 
     #[test]
@@ -442,9 +456,70 @@ mod tests {
 
     #[test]
     #[serial]
-    fn mock_store_set_basic_test() {
+    fn mock_store_get_in_block_basic_test() {
         let mut context = get_context();
 
+        context.cache_store.insert("entity".to_owned(), HashMap::new());
+        let mut inner_map = context
+            .cache_store
+            .get("entity")
+            .expect("Couldn't get inner map.")
+            .clone();
+        inner_map.insert("id".to_owned(), HashMap::new());
+        let mut entity = inner_map
+            .get("id")
+            .expect("Couldn't get value from inner map.")
+            .clone();
+        entity.insert("field_name".to_owned(), Value::String("val".to_owned()));
+        inner_map.insert("id".to_owned(), entity);
+        context.cache_store.insert("entity".to_owned(), inner_map);
+
+        let entity = asc_string_from_str("entity");
+        let id = asc_string_from_str("id");
+        let entity_pointer = AscPtr::alloc_obj(entity, &mut context.wasm_ctx, &GasCounter::new())
+            .expect("Couldn't create pointer.");
+        let id_pointer = AscPtr::alloc_obj(id, &mut context.wasm_ctx, &GasCounter::new())
+            .expect("Couldn't create pointer.");
+
+        let value = context
+            .mock_store_get_in_block(&GasCounter::new(), entity_pointer, id_pointer)
+            .expect("Couldn't call mock_store_get.");
+
+        assert_eq!(
+            value
+                .read_ptr(&context.wasm_ctx, &GasCounter::new())
+                .unwrap()
+                .content_len(
+                    &value
+                        .read_ptr(&context.wasm_ctx, &GasCounter::new())
+                        .unwrap()
+                        .to_asc_bytes()
+                        .expect("Couldn't get entity bytes.")
+                ),
+            4
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn mock_store_get_in_block_no_such_entity() {
+        let mut context = get_context();
+
+        let entity = asc_string_from_str("entity");
+        let id = asc_string_from_str("id");
+        let entity_pointer = AscPtr::alloc_obj(entity, &mut context.wasm_ctx, &GasCounter::new())
+            .expect("Couldn't create pointer.");
+        let id_pointer = AscPtr::alloc_obj(id, &mut context.wasm_ctx, &GasCounter::new())
+            .expect("Couldn't create pointer.");
+
+        let value = context
+            .mock_store_get_in_block(&GasCounter::new(), entity_pointer, id_pointer)
+            .expect("Couldn't call mock_store_get.");
+
+        assert!(value.is_null());
+    }
+
+    fn prepare_entity_store_pointers(context: &mut MatchstickInstanceContext<Chain>) -> (AscPtr<AscString>, AscPtr<AscString>, AscPtr<AscTypedMap<AscString, AscEnum<StoreValueKind>>>) {
         let entity = asc_string_from_str("entity");
         let id = asc_string_from_str("id");
         let entity_pointer = AscPtr::alloc_obj(entity, &mut context.wasm_ctx, &GasCounter::new())
@@ -480,6 +555,16 @@ mod tests {
         };
         let asc_map_pointer = AscPtr::alloc_obj(asc_map, &mut context.wasm_ctx, &GasCounter::new())
             .expect("Couldn't create pointer.");
+
+        return (entity_pointer, id_pointer, asc_map_pointer);
+    }
+
+    #[test]
+    #[serial]
+    fn mock_store_set_basic_test() {
+        let mut context = get_context();
+
+        let (entity_pointer, id_pointer, asc_map_pointer,) = prepare_entity_store_pointers(&mut context);
 
         context
             .mock_store_set(
@@ -502,12 +587,7 @@ mod tests {
     fn mock_store_set_existing_entity_type() {
         let mut context = get_context();
 
-        let entity = asc_string_from_str("entity");
-        let id = asc_string_from_str("id");
-        let entity_pointer = AscPtr::alloc_obj(entity, &mut context.wasm_ctx, &GasCounter::new())
-            .expect("Couldn't create pointer.");
-        let id_pointer = AscPtr::alloc_obj(id, &mut context.wasm_ctx, &GasCounter::new())
-            .expect("Couldn't create pointer.");
+        let (entity_pointer, id_pointer, asc_map_pointer,) = prepare_entity_store_pointers(&mut context);
 
         context.store.insert("entity".to_owned(), HashMap::new());
         let mut inner_map = context
@@ -517,37 +597,7 @@ mod tests {
             .clone();
         inner_map.insert("another_id".to_owned(), HashMap::new());
         context.store.insert("entity".to_owned(), inner_map);
-
-        let payload = AscEnum::<StoreValueKind> {
-            kind: StoreValueKind::String,
-            _padding: 0,
-            payload: EnumPayload::from(id_pointer),
-        };
-        let payload_pointer = AscPtr::alloc_obj(payload, &mut context.wasm_ctx, &GasCounter::new())
-            .expect("Couldn't create pointer.");
-        let map_entry = AscTypedMapEntry {
-            key: id_pointer,
-            value: payload_pointer,
-        };
-        let map_entry_pointer =
-            AscPtr::alloc_obj(map_entry, &mut context.wasm_ctx, &GasCounter::new())
-                .expect("Couldn't create pointer.");
-        let asc_map = AscTypedMap {
-            entries: AscPtr::alloc_obj(
-                Array::new(
-                    &[map_entry_pointer],
-                    &mut context.wasm_ctx,
-                    &GasCounter::new(),
-                )
-                .expect("Couldn't create Array."),
-                &mut context.wasm_ctx,
-                &GasCounter::new(),
-            )
-            .expect("Couldn't create pointer."),
-        };
-        let asc_map_pointer = AscPtr::alloc_obj(asc_map, &mut context.wasm_ctx, &GasCounter::new())
-            .expect("Couldn't create pointer.");
-
+        
         context
             .mock_store_set(
                 &GasCounter::new(),
@@ -671,6 +721,183 @@ mod tests {
             .expect("Couldn't get inner map.")
             .get("graphAccountId")
             .unwrap();
+
+        assert_eq!(
+            inner_map
+                .get("nameSignalTransactions")
+                .unwrap()
+                .clone()
+                .as_list()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn cache_store_set_basic_test() {
+        let mut context = get_context();
+
+        let (entity_pointer, id_pointer, asc_map_pointer,) = prepare_entity_store_pointers(&mut context);
+
+        context
+            .cache_store_set(
+                &GasCounter::new(),
+                entity_pointer,
+                id_pointer,
+                asc_map_pointer,
+            )
+            .expect("Couldn't call cache_store_set.");
+
+        let inner_map = context
+            .cache_store
+            .get("entity")
+            .expect("Couldn't get inner map.");
+        assert_eq!(inner_map.len(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn cache_store_set_existing_entity_type() {
+        let mut context = get_context();
+
+        let (entity_pointer, id_pointer, asc_map_pointer,) = prepare_entity_store_pointers(&mut context);
+
+        context.cache_store.insert("entity".to_owned(), HashMap::new());
+        let mut inner_map = context
+            .cache_store
+            .get("entity")
+            .expect("Couldn't get inner map.")
+            .clone();
+        inner_map.insert("another_id".to_owned(), HashMap::new());
+        context.cache_store.insert("entity".to_owned(), inner_map);
+        
+        context
+            .cache_store_set(
+                &GasCounter::new(),
+                entity_pointer,
+                id_pointer,
+                asc_map_pointer,
+            )
+            .expect("Couldn't call cache_store_get.");
+
+        let inner_map = context
+            .cache_store
+            .get("entity")
+            .expect("Couldn't get inner map.");
+        assert_eq!(inner_map.len(), 2);
+    }
+
+    #[test]
+    #[serial]
+    fn cache_store_set_derived_fields() {
+        let mut context = get_context();
+
+        let nst = asc_string_from_str("NameSignalTransaction");
+        let id = asc_string_from_str("nstid");
+        let id_key = asc_string_from_str("id");
+        let signer_key = asc_string_from_str("signer");
+        let signer_value = asc_string_from_str("graphAccountId");
+        let entity_pointer = AscPtr::alloc_obj(nst, &mut context.wasm_ctx, &GasCounter::new())
+            .expect("Couldn't create pointer.");
+        let id_pointer = AscPtr::alloc_obj(id, &mut context.wasm_ctx, &GasCounter::new())
+            .expect("Couldn't create pointer.");
+        let id_key_pointer = AscPtr::alloc_obj(id_key, &mut context.wasm_ctx, &GasCounter::new())
+            .expect("Couldn't create pointer.");
+        let signer_key_pointer =
+            AscPtr::alloc_obj(signer_key, &mut context.wasm_ctx, &GasCounter::new())
+                .expect("Couldn't create pointer.");
+        let signer_value_pointer =
+            AscPtr::alloc_obj(signer_value, &mut context.wasm_ctx, &GasCounter::new())
+                .expect("Couldn't create pointer.");
+
+        context
+            .cache_store
+            .insert("GraphAccount".to_owned(), HashMap::new());
+        let mut inner_map = context
+            .cache_store
+            .get("GraphAccount")
+            .expect("Couldn't get inner map.")
+            .clone();
+        inner_map.insert("graphAccountId".to_owned(), HashMap::new());
+        context.cache_store.insert("GraphAccount".to_owned(), inner_map);
+        context.derived.insert(
+            "NameSignalTransaction".to_owned(),
+            vec![(
+                "nameSignalTransactions".to_owned(),
+                "signer".to_owned(),
+                "GraphAccount".to_owned(),
+            )],
+        );
+
+        // Create signer field parameter
+        let signer_payload = AscEnum::<StoreValueKind> {
+            kind: StoreValueKind::String,
+            _padding: 0,
+            payload: EnumPayload::from(signer_value_pointer),
+        };
+        let signer_payload_pointer =
+            AscPtr::alloc_obj(signer_payload, &mut context.wasm_ctx, &GasCounter::new())
+                .expect("Couldn't create pointer.");
+        let signer_entry = AscTypedMapEntry {
+            key: signer_key_pointer,
+            value: signer_payload_pointer,
+        };
+        let signer_entry_pointer =
+            AscPtr::alloc_obj(signer_entry, &mut context.wasm_ctx, &GasCounter::new())
+                .expect("Couldn't create pointer.");
+
+        // Create ID field parameter
+        let id_payload = AscEnum::<StoreValueKind> {
+            kind: StoreValueKind::String,
+            _padding: 0,
+            payload: EnumPayload::from(id_pointer),
+        };
+        let id_payload_pointer =
+            AscPtr::alloc_obj(id_payload, &mut context.wasm_ctx, &GasCounter::new())
+                .expect("Couldn't create pointer.");
+        let id_entry = AscTypedMapEntry {
+            key: id_key_pointer,
+            value: id_payload_pointer,
+        };
+        let id_entry_pointer =
+            AscPtr::alloc_obj(id_entry, &mut context.wasm_ctx, &GasCounter::new())
+                .expect("Couldn't create pointer.");
+
+        let asc_map = AscTypedMap {
+            entries: AscPtr::alloc_obj(
+                Array::new(
+                    &[id_entry_pointer, signer_entry_pointer],
+                    &mut context.wasm_ctx,
+                    &GasCounter::new(),
+                )
+                .expect("Couldn't create Array."),
+                &mut context.wasm_ctx,
+                &GasCounter::new(),
+            )
+            .expect("Couldn't create pointer."),
+        };
+        let asc_map_pointer = AscPtr::alloc_obj(asc_map, &mut context.wasm_ctx, &GasCounter::new())
+            .expect("Couldn't create pointer.");
+
+        context
+            .cache_store_set(
+                &GasCounter::new(),
+                entity_pointer,
+                id_pointer,
+                asc_map_pointer,
+            )
+            .expect("Couldn't call cache_store_set.");
+
+        let inner_map = context
+            .cache_store
+            .get("GraphAccount")
+            .expect("Couldn't get inner map.")
+            .get("graphAccountId")
+            .unwrap();
+
+
         assert_eq!(
             inner_map
                 .get("nameSignalTransactions")

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -12,8 +12,8 @@ mod tests {
     };
     use graph_chain_ethereum::{runtime::abi::AscUnresolvedContractCall_0_0_4, Chain};
     use graph_runtime_wasm::asc_abi::class::{
-        Array, AscEnum, AscTypedMap, AscTypedMapEntry, EnumPayload, EthereumValueKind,
-        StoreValueKind, TypedArray, AscString,
+        Array, AscEnum, AscString, AscTypedMap, AscTypedMapEntry, EnumPayload, EthereumValueKind,
+        StoreValueKind, TypedArray,
     };
     use serial_test::serial;
 
@@ -94,7 +94,9 @@ mod tests {
     fn clear_cache_store_basic_test() {
         let mut context = get_context();
 
-        context.cache_store.insert("type".to_owned(), HashMap::new());
+        context
+            .cache_store
+            .insert("type".to_owned(), HashMap::new());
 
         context
             .clear_cache_store(&GasCounter::new())
@@ -459,7 +461,9 @@ mod tests {
     fn mock_store_get_in_block_basic_test() {
         let mut context = get_context();
 
-        context.cache_store.insert("entity".to_owned(), HashMap::new());
+        context
+            .cache_store
+            .insert("entity".to_owned(), HashMap::new());
         let mut inner_map = context
             .cache_store
             .get("entity")
@@ -519,7 +523,13 @@ mod tests {
         assert!(value.is_null());
     }
 
-    fn prepare_entity_store_pointers(context: &mut MatchstickInstanceContext<Chain>) -> (AscPtr<AscString>, AscPtr<AscString>, AscPtr<AscTypedMap<AscString, AscEnum<StoreValueKind>>>) {
+    fn prepare_entity_store_pointers(
+        context: &mut MatchstickInstanceContext<Chain>,
+    ) -> (
+        AscPtr<AscString>,
+        AscPtr<AscString>,
+        AscPtr<AscTypedMap<AscString, AscEnum<StoreValueKind>>>,
+    ) {
         let entity = asc_string_from_str("entity");
         let id = asc_string_from_str("id");
         let entity_pointer = AscPtr::alloc_obj(entity, &mut context.wasm_ctx, &GasCounter::new())
@@ -564,7 +574,8 @@ mod tests {
     fn mock_store_set_basic_test() {
         let mut context = get_context();
 
-        let (entity_pointer, id_pointer, asc_map_pointer,) = prepare_entity_store_pointers(&mut context);
+        let (entity_pointer, id_pointer, asc_map_pointer) =
+            prepare_entity_store_pointers(&mut context);
 
         context
             .mock_store_set(
@@ -587,7 +598,8 @@ mod tests {
     fn mock_store_set_existing_entity_type() {
         let mut context = get_context();
 
-        let (entity_pointer, id_pointer, asc_map_pointer,) = prepare_entity_store_pointers(&mut context);
+        let (entity_pointer, id_pointer, asc_map_pointer) =
+            prepare_entity_store_pointers(&mut context);
 
         context.store.insert("entity".to_owned(), HashMap::new());
         let mut inner_map = context
@@ -597,7 +609,7 @@ mod tests {
             .clone();
         inner_map.insert("another_id".to_owned(), HashMap::new());
         context.store.insert("entity".to_owned(), inner_map);
-        
+
         context
             .mock_store_set(
                 &GasCounter::new(),
@@ -739,7 +751,8 @@ mod tests {
     fn cache_store_set_basic_test() {
         let mut context = get_context();
 
-        let (entity_pointer, id_pointer, asc_map_pointer,) = prepare_entity_store_pointers(&mut context);
+        let (entity_pointer, id_pointer, asc_map_pointer) =
+            prepare_entity_store_pointers(&mut context);
 
         context
             .cache_store_set(
@@ -762,9 +775,12 @@ mod tests {
     fn cache_store_set_existing_entity_type() {
         let mut context = get_context();
 
-        let (entity_pointer, id_pointer, asc_map_pointer,) = prepare_entity_store_pointers(&mut context);
+        let (entity_pointer, id_pointer, asc_map_pointer) =
+            prepare_entity_store_pointers(&mut context);
 
-        context.cache_store.insert("entity".to_owned(), HashMap::new());
+        context
+            .cache_store
+            .insert("entity".to_owned(), HashMap::new());
         let mut inner_map = context
             .cache_store
             .get("entity")
@@ -772,7 +788,7 @@ mod tests {
             .clone();
         inner_map.insert("another_id".to_owned(), HashMap::new());
         context.cache_store.insert("entity".to_owned(), inner_map);
-        
+
         context
             .cache_store_set(
                 &GasCounter::new(),
@@ -821,7 +837,9 @@ mod tests {
             .expect("Couldn't get inner map.")
             .clone();
         inner_map.insert("graphAccountId".to_owned(), HashMap::new());
-        context.cache_store.insert("GraphAccount".to_owned(), inner_map);
+        context
+            .cache_store
+            .insert("GraphAccount".to_owned(), inner_map);
         context.derived.insert(
             "NameSignalTransaction".to_owned(),
             vec![(
@@ -896,7 +914,6 @@ mod tests {
             .expect("Couldn't get inner map.")
             .get("graphAccountId")
             .unwrap();
-
 
         assert_eq!(
             inner_map


### PR DESCRIPTION
closes https://github.com/LimeChain/matchstick/issues/400

Add 2 external functions to manipulate the storage, used by `loadInBlock` method:
* `mockInBlockStore` - add a new entity to the store
* `clearInBlockStore` - removes all mocked entities from the store